### PR TITLE
Fix root scripts linting

### DIFF
--- a/add_katex.py
+++ b/add_katex.py
@@ -11,9 +11,9 @@ This script:
 6. Adds KaTeX CSS/JS to <head> and auto-render script to <body>
 """
 
-import re
 import glob
 import os
+import re
 
 DOCS_DIR = r"C:\source\erisml-lib\docs"
 SUBDIRS = [
@@ -86,7 +86,7 @@ def fix_star_corruption(html):
 
     # PASS 1: Fix var^<em></em> (empty italic from ^*)
     # e.g., h^<em></em> -> h^*
-    html = re.sub(r'(\w)\^<em></em>', r'\1^*', html)
+    html = re.sub(r"(\w)\^<em></em>", r"\1^*", html)
 
     # PASS 2: Fix var^<em>(content)</em> inside <em class="math">
     # e.g., <em class="math">h^<em>(x)</em> -> <em class="math">h^*(x)</em>
@@ -94,9 +94,7 @@ def fix_star_corruption(html):
     # We apply this repeatedly since there may be multiple in one math span
     for _ in range(5):
         new = re.sub(
-            r'(<em class="math">[^<]*?)\^<em>([^<]*?)</em>',
-            r'\1^*\2</em>',
-            html
+            r'(<em class="math">[^<]*?)\^<em>([^<]*?)</em>', r"\1^*\2</em>", html
         )
         if new == html:
             break
@@ -108,9 +106,7 @@ def fix_star_corruption(html):
     # We need: <em class="math">h(x) = h^*(x)</em>
     for _ in range(5):
         new = re.sub(
-            r'(<em class="math">[^<]*?)\^</em>([^<]*?)</em>',
-            r'\1^*\2</em>',
-            html
+            r'(<em class="math">[^<]*?)\^</em>([^<]*?)</em>', r"\1^*\2</em>", html
         )
         if new == html:
             break
@@ -118,7 +114,7 @@ def fix_star_corruption(html):
 
     # PASS 4: Fix var^</em> outside math em
     # Standalone occurrences like g^</em> -> g^*
-    html = re.sub(r'(\w)\^</em>', r'\1^*', html)
+    html = re.sub(r"(\w)\^</em>", r"\1^*", html)
 
     # PASS 5: Fix the A* italic pairs.
     # Pattern: A<em> ... </em> where the * from A* opens italic
@@ -135,13 +131,13 @@ def fix_star_corruption(html):
 
     # PASS 6: Any remaining standalone A</em> -> A*
     # But NOT when preceded by > (which means it's inside <em class="math">A</em>)
-    html = re.sub(r'(?<=[^a-zA-Z>])A</em>(?=[^<])', 'A*', html)
+    html = re.sub(r"(?<=[^a-zA-Z>])A</em>(?=[^<])", "A*", html)
 
     # PASS 7: Any remaining orphaned A<em> (where matching </em> was consumed
     # by earlier passes). Replace A<em> followed by a space with A*.
     # But NOT A<em class= (which is <em class="math">)
-    html = re.sub(r'(?<=[^a-zA-Z])A<em>(?=[\s,.])', 'A*', html)
-    html = re.sub(r'(?<=[^a-zA-Z])A<em>(?=<strong>)', 'A*', html)
+    html = re.sub(r"(?<=[^a-zA-Z])A<em>(?=[\s,.])", "A*", html)
+    html = re.sub(r"(?<=[^a-zA-Z])A<em>(?=<strong>)", "A*", html)
 
     return html
 
@@ -154,8 +150,12 @@ def _fix_a_star_pairs(html):
 
     while i < n:
         # Look for A<em> preceded by non-alpha (or start of string)
-        if (i < n - 4 and html[i] == 'A' and html[i+1:i+5] == '<em>'
-                and (i == 0 or not html[i-1].isalpha())):
+        if (
+            i < n - 4
+            and html[i] == "A"
+            and html[i + 1 : i + 5] == "<em>"
+            and (i == 0 or not html[i - 1].isalpha())
+        ):
 
             # Found A<em> - need to find matching </em>
             # Track depth to skip over <em class="math">...</em> pairs
@@ -163,26 +163,34 @@ def _fix_a_star_pairs(html):
             j = i + 5  # position after A<em>
 
             while j < n and depth > 0:
-                if html[j:j+17] == '<em class="math">':
+                if html[j : j + 17] == '<em class="math">':
                     depth += 1
                     j += 17
-                elif html[j:j+4] == '<em>' and not html[j:j+17].startswith('<em class='):
+                elif html[j : j + 4] == "<em>" and not html[j : j + 17].startswith(
+                    "<em class="
+                ):
                     # Another bare <em> (italic start, not a class="math" em)
                     depth += 1
                     j += 4
-                elif html[j:j+5] == '</em>':
+                elif html[j : j + 5] == "</em>":
                     depth -= 1
                     if depth == 0:
                         # Found the matching </em>
-                        inner = html[i+5:j]
-                        result.append('A*')
+                        inner = html[i + 5 : j]
+                        result.append("A*")
 
                         # Check if inner ends with A (another A*)
                         # e.g., "...text, A" where A</em> was the pattern
-                        if inner.endswith(' A') or inner.endswith(',A') or inner.endswith(', A'):
+                        if (
+                            inner.endswith(" A")
+                            or inner.endswith(",A")
+                            or inner.endswith(", A")
+                        ):
                             # The A at the end was the second A*, append *
-                            result.append(inner[:-1])  # everything except the trailing A
-                            result.append('A*')
+                            result.append(
+                                inner[:-1]
+                            )  # everything except the trailing A
+                            result.append("A*")
                         else:
                             result.append(inner)
 
@@ -200,27 +208,28 @@ def _fix_a_star_pairs(html):
             result.append(html[i])
             i += 1
 
-    return ''.join(result)
+    return "".join(result)
 
 
 def fix_table_display_math(html):
     """Fix display math equations split across table <th>/<td> cells."""
+
     def rebuild_table_math(match):
         full_table = match.group(0)
 
-        if '$$' not in full_table:
+        if "$$" not in full_table:
             return full_table
 
-        rows = re.findall(r'<tr>(.*?)</tr>', full_table, re.DOTALL)
+        rows = re.findall(r"<tr>(.*?)</tr>", full_table, re.DOTALL)
         if not rows:
             return full_table
 
         result_parts = []
         for row in rows:
-            cells = re.findall(r'<t[hd](?:\s[^>]*)?>(.*?)</t[hd]>', row, re.DOTALL)
+            cells = re.findall(r"<t[hd](?:\s[^>]*)?>(.*?)</t[hd]>", row, re.DOTALL)
             if not cells:
                 continue
-            joined = ''.join(cells).strip()
+            joined = "".join(cells).strip()
             if joined:
                 result_parts.append(joined)
 
@@ -230,33 +239,34 @@ def fix_table_display_math(html):
         output_parts = []
         for part in result_parts:
             stripped = part.strip()
-            if stripped.startswith('$$') or '$$' in stripped:
+            if stripped.startswith("$$") or "$$" in stripped:
                 output_parts.append(f'<p class="display-math">{stripped}</p>')
             else:
                 output_parts.append(f'<p class="body-text">{stripped}</p>')
 
-        return '\n'.join(output_parts)
+        return "\n".join(output_parts)
 
     html = re.sub(
         r'<div class="table-wrapper"><table class="book-table">.*?</table></div>',
         rebuild_table_math,
         html,
-        flags=re.DOTALL
+        flags=re.DOTALL,
     )
     return html
 
 
 def fix_em_math_tags(html):
     """Replace <em class="math">content</em> with $content$."""
+
     def replace_em_math(match):
         content = match.group(1)
-        content = re.sub(r'<sub>(.*?)</sub>', r'_{\1}', content)
-        content = re.sub(r'<sup>(.*?)</sup>', r'^{\1}', content)
-        content = re.sub(r'<[^>]+>', '', content)
-        content = content.replace('&gt;', '>')
-        content = content.replace('&lt;', '<')
-        content = content.replace('&amp;', '&')
-        return f'${content}$'
+        content = re.sub(r"<sub>(.*?)</sub>", r"_{\1}", content)
+        content = re.sub(r"<sup>(.*?)</sup>", r"^{\1}", content)
+        content = re.sub(r"<[^>]+>", "", content)
+        content = content.replace("&gt;", ">")
+        content = content.replace("&lt;", "<")
+        content = content.replace("&amp;", "&")
+        return f"${content}$"
 
     html = re.sub(r'<em class="math">(.*?)</em>', replace_em_math, html)
     return html
@@ -264,15 +274,16 @@ def fix_em_math_tags(html):
 
 def fix_math_block_spans(html):
     """Replace <span class="math-block">content</span> with $$content$$."""
+
     def replace_math_block(match):
         content = match.group(1)
-        content = re.sub(r'<sub>(.*?)</sub>', r'_{\1}', content)
-        content = re.sub(r'<sup>(.*?)</sup>', r'^{\1}', content)
-        content = re.sub(r'<[^>]+>', '', content)
-        content = content.replace('&gt;', '>')
-        content = content.replace('&lt;', '<')
-        content = content.replace('&amp;', '&')
-        return f'$${content}$$'
+        content = re.sub(r"<sub>(.*?)</sub>", r"_{\1}", content)
+        content = re.sub(r"<sup>(.*?)</sup>", r"^{\1}", content)
+        content = re.sub(r"<[^>]+>", "", content)
+        content = content.replace("&gt;", ">")
+        content = content.replace("&lt;", "<")
+        content = content.replace("&amp;", "&")
+        return f"$${content}$$"
 
     html = re.sub(r'<span class="math-block">(.*?)</span>', replace_math_block, html)
     return html
@@ -280,30 +291,40 @@ def fix_math_block_spans(html):
 
 def fix_display_math_p(html):
     """Ensure <p class='display-math'> content is wrapped in $$."""
+
     def replace_display_math(match):
         content = match.group(1).strip()
-        if content.startswith('$$') and content.endswith('$$'):
+        if content.startswith("$$") and content.endswith("$$"):
             return match.group(0)
-        if content.startswith('$') and content.endswith('$') and not content.startswith('$$'):
+        if (
+            content.startswith("$")
+            and content.endswith("$")
+            and not content.startswith("$$")
+        ):
             inner = content[1:-1]
             return f'<p class="display-math">$${inner}$$</p>'
-        if not content.startswith('$$'):
-            content = f'$${content}$$'
+        if not content.startswith("$$"):
+            content = f"$${content}$$"
         return f'<p class="display-math">{content}</p>'
 
-    html = re.sub(r'<p class="display-math">(.*?)</p>', replace_display_math, html, flags=re.DOTALL)
+    html = re.sub(
+        r'<p class="display-math">(.*?)</p>',
+        replace_display_math,
+        html,
+        flags=re.DOTALL,
+    )
     return html
 
 
 def fix_stray_artifacts(html):
     """Clean up remaining artifacts."""
     # Fix triple+ dollar signs
-    html = re.sub(r'\${3,}', '$$', html)
+    html = re.sub(r"\${3,}", "$$", html)
     return html
 
 
 def process_file(filepath):
-    with open(filepath, 'r', encoding='utf-8') as f:
+    with open(filepath, "r", encoding="utf-8") as f:
         original = f.read()
 
     html = original
@@ -331,7 +352,7 @@ def process_file(filepath):
     html = add_katex_body(html)
 
     if html != original:
-        with open(filepath, 'w', encoding='utf-8') as f:
+        with open(filepath, "w", encoding="utf-8") as f:
             f.write(html)
         return True
     return False
@@ -363,6 +384,7 @@ def main():
                     print(f"  unchanged: {filename}")
             except Exception as e:
                 import traceback
+
                 print(f"  ERROR: {filename}: {e}")
                 traceback.print_exc()
 

--- a/build_books.py
+++ b/build_books.py
@@ -21,15 +21,12 @@ Usage:
 
 import argparse
 import json
-import os
 import re
-import shutil
 import subprocess
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
-
 
 # ── Configuration ──────────────────────────────────────────────────────────
 
@@ -43,6 +40,7 @@ AUTHOR = "Andrew H. Bond"
 @dataclass
 class ChapterSource:
     """A single markdown chapter source file."""
+
     md_path: Path
     chapter_num: int  # 0 for front matter
 
@@ -50,14 +48,15 @@ class ChapterSource:
 @dataclass
 class BookConfig:
     """Configuration for one book in the series."""
-    key: str                    # e.g. "medicine"
-    dir_name: str               # e.g. "geometric-medicine" (output dir in docs/)
-    title: str                  # e.g. "Geometric Medicine"
-    subtitle: str               # e.g. "Clinical Reasoning, Triage, and the Ethics of Allocation"
-    source_repo: Path           # root of source repo
-    chapter_sources: list       # list of (part_dir_or_chapters_dir, pattern) tuples
-    nav_key: str                # e.g. "nav-medicine" — for active nav highlighting
-    book_number: int            # e.g. 8
+
+    key: str  # e.g. "medicine"
+    dir_name: str  # e.g. "geometric-medicine" (output dir in docs/)
+    title: str  # e.g. "Geometric Medicine"
+    subtitle: str  # e.g. "Clinical Reasoning, Triage, and the Ethics of Allocation"
+    source_repo: Path  # root of source repo
+    chapter_sources: list  # list of (part_dir_or_chapters_dir, pattern) tuples
+    nav_key: str  # e.g. "nav-medicine" — for active nav highlighting
+    book_number: int  # e.g. 8
 
     def get_output_dir(self) -> Path:
         return DOCS_DIR / self.dir_name
@@ -197,6 +196,7 @@ def get_book_configs() -> dict[str, BookConfig]:
 
 # ── Chapter Discovery ──────────────────────────────────────────────────────
 
+
 def discover_chapters(book: BookConfig) -> list[ChapterSource]:
     """Find all chapter markdown files for a book, sorted by chapter number."""
     chapters = []
@@ -244,12 +244,12 @@ def extract_title_from_md(md_path: Path) -> str:
 def slugify(title: str) -> str:
     """Convert a chapter title to a URL-friendly slug."""
     # Remove LaTeX math
-    slug = re.sub(r'\$[^$]+\$', '', title)
+    slug = re.sub(r"\$[^$]+\$", "", title)
     slug = slug.lower()
-    slug = re.sub(r'[^a-z0-9\s-]', '', slug)
-    slug = re.sub(r'[\s]+', '-', slug.strip())
-    slug = re.sub(r'-+', '-', slug)
-    slug = slug.strip('-')
+    slug = re.sub(r"[^a-z0-9\s-]", "", slug)
+    slug = re.sub(r"[\s]+", "-", slug.strip())
+    slug = re.sub(r"-+", "-", slug)
+    slug = slug.strip("-")
     return slug
 
 
@@ -258,19 +258,19 @@ def make_output_filename(chapter: ChapterSource, title: str) -> str:
     if chapter.chapter_num == 0:
         return "front-matter.html"
     # Strip "Chapter N:" prefix before slugifying to avoid double numbering
-    clean_title = re.sub(r'^Chapter\s+\d+\s*:\s*', '', title)
+    clean_title = re.sub(r"^Chapter\s+\d+\s*:\s*", "", title)
     slug = slugify(clean_title)
     return f"chapter-{chapter.chapter_num}-{slug}.html"
 
 
 # ── Pandoc Conversion ─────────────────────────────────────────────────────
 
+
 def check_pandoc() -> bool:
     """Check if Pandoc is installed and return True if available."""
     try:
         result = subprocess.run(
-            ["pandoc", "--version"],
-            capture_output=True, text=True, timeout=10
+            ["pandoc", "--version"], capture_output=True, text=True, timeout=10
         )
         if result.returncode == 0:
             version = result.stdout.split("\n")[0]
@@ -322,11 +322,15 @@ def convert_chapter_pandoc(
     cmd = [
         "pandoc",
         str(md_path),
-        "--from", "markdown+tex_math_dollars+tex_math_single_backslash",
-        "--to", "html5",
+        "--from",
+        "markdown+tex_math_dollars+tex_math_single_backslash",
+        "--to",
+        "html5",
         "--katex",
-        "--template", str(TEMPLATE),
-        "--output", str(output_path),
+        "--template",
+        str(TEMPLATE),
+        "--output",
+        str(output_path),
         "--wrap=none",
         "--section-divs",
     ]
@@ -358,6 +362,7 @@ def convert_chapter_pandoc(
 
 
 # ── Post-processing ───────────────────────────────────────────────────────
+
 
 def get_existing_output_filename(book: BookConfig, chapter_num: int) -> Optional[str]:
     """Look up the existing HTML filename for a chapter in the current docs.
@@ -414,16 +419,19 @@ def build_chapter_list(
         else:
             filename = make_output_filename(ch, title)
 
-        chapter_list.append({
-            "source": ch,
-            "title": title,
-            "filename": filename,
-        })
+        chapter_list.append(
+            {
+                "source": ch,
+                "title": title,
+                "filename": filename,
+            }
+        )
 
     return chapter_list
 
 
 # ── Main Build Logic ──────────────────────────────────────────────────────
+
 
 def build_book(book: BookConfig, dry_run: bool = False) -> tuple[int, int]:
     """Build all chapters for one book. Returns (success_count, fail_count)."""
@@ -460,7 +468,9 @@ def build_book(book: BookConfig, dry_run: bool = False) -> tuple[int, int]:
         # Determine prev/next
         prev_url = chapter_list[i - 1]["filename"] if i > 0 else None
         prev_title = chapter_list[i - 1]["title"] if i > 0 else None
-        next_url = chapter_list[i + 1]["filename"] if i < len(chapter_list) - 1 else None
+        next_url = (
+            chapter_list[i + 1]["filename"] if i < len(chapter_list) - 1 else None
+        )
         next_title = chapter_list[i + 1]["title"] if i < len(chapter_list) - 1 else None
 
         ok = convert_chapter_pandoc(
@@ -514,8 +524,16 @@ def build_single_chapter(
 
     prev_url = chapter_list[target_idx - 1]["filename"] if target_idx > 0 else None
     prev_title = chapter_list[target_idx - 1]["title"] if target_idx > 0 else None
-    next_url = chapter_list[target_idx + 1]["filename"] if target_idx < len(chapter_list) - 1 else None
-    next_title = chapter_list[target_idx + 1]["title"] if target_idx < len(chapter_list) - 1 else None
+    next_url = (
+        chapter_list[target_idx + 1]["filename"]
+        if target_idx < len(chapter_list) - 1
+        else None
+    )
+    next_title = (
+        chapter_list[target_idx + 1]["title"]
+        if target_idx < len(chapter_list) - 1
+        else None
+    )
 
     output_path = output_dir / target["filename"]
 
@@ -546,8 +564,8 @@ def validate_output(html_path: Path) -> dict:
     issues = []
 
     # Check for unclosed <em> tags (the old bug)
-    em_opens = len(re.findall(r'<em\b', content))
-    em_closes = len(re.findall(r'</em>', content))
+    em_opens = len(re.findall(r"<em\b", content))
+    em_closes = len(re.findall(r"</em>", content))
     if em_opens != em_closes:
         issues.append(f"Unclosed <em> tags: {em_opens} opens vs {em_closes} closes")
 
@@ -562,12 +580,15 @@ def validate_output(html_path: Path) -> dict:
 
     # Check for unrendered dollar signs that suggest math wasn't processed
     # (exclude those inside <span class="math"> elements, and currency like $200,000)
-    stripped = re.sub(r'<span class="math[^"]*">.*?</span>', '', content, flags=re.DOTALL)
+    stripped = re.sub(
+        r'<span class="math[^"]*">.*?</span>', "", content, flags=re.DOTALL
+    )
     # Match $...$ but exclude currency amounts ($123, $4.2B, $200K, etc.)
-    stray_dollar_matches = re.findall(r'(?<![\\])\$[^$]+\$', stripped)
+    stray_dollar_matches = re.findall(r"(?<![\\])\$[^$]+\$", stripped)
     stray_dollars = sum(
-        1 for m in stray_dollar_matches
-        if not re.match(r'^\$[\d,.]+[KMBkmb]?\$?', m)  # not currency
+        1
+        for m in stray_dollar_matches
+        if not re.match(r"^\$[\d,.]+[KMBkmb]?\$?", m)  # not currency
     )
 
     # Check for KaTeX CSS/JS references
@@ -590,13 +611,25 @@ def validate_output(html_path: Path) -> dict:
 
 # ── CLI ────────────────────────────────────────────────────────────────────
 
+
 def main():
     parser = argparse.ArgumentParser(
         description="Build Geometric Series book chapters from Markdown to HTML via Pandoc."
     )
     parser.add_argument(
         "--book",
-        choices=["reasoning", "economics", "law", "cognition", "communication", "medicine", "education", "politics", "ai", "all"],
+        choices=[
+            "reasoning",
+            "economics",
+            "law",
+            "cognition",
+            "communication",
+            "medicine",
+            "education",
+            "politics",
+            "ai",
+            "all",
+        ],
         default="all",
         help="Which book to build (default: all)",
     )
@@ -657,10 +690,13 @@ def main():
             if ch13_file:
                 output_path = output_dir / ch13_file
             else:
-                output_path = output_dir / "chapter-13-the-mathematical-theory-of-moral-injury.html"
+                output_path = (
+                    output_dir
+                    / "chapter-13-the-mathematical-theory-of-moral-injury.html"
+                )
 
             if output_path.exists():
-                print(f"\n--- Validation ---")
+                print("\n--- Validation ---")
                 result = validate_output(output_path)
                 print(f"  File size: {result['file_size']:,} bytes")
                 print(f"  Math inline spans: {result['math_inline_spans']}")
@@ -668,14 +704,16 @@ def main():
                 print(f"  KaTeX CSS: {'yes' if result['has_katex_css'] else 'NO'}")
                 print(f"  KaTeX JS: {'yes' if result['has_katex_js'] else 'NO'}")
                 print(f"  Old <em class='math'> tags: {result['old_math_em_tags']}")
-                print(f"  Unclosed <em> tags: {'YES - BUG!' if result['unclosed_em_tags'] else 'none'}")
+                print(
+                    f"  Unclosed <em> tags: {'YES - BUG!' if result['unclosed_em_tags'] else 'none'}"
+                )
                 print(f"  Stray $ math: {result['stray_dollar_math']}")
                 if result["issues"]:
-                    print(f"\n  ISSUES:")
+                    print("\n  ISSUES:")
                     for issue in result["issues"]:
                         print(f"    - {issue}")
                 else:
-                    print(f"\n  All checks passed.")
+                    print("\n  All checks passed.")
             else:
                 print(f"  Output file not found for validation: {output_path}")
 

--- a/fix_all_em_balance.py
+++ b/fix_all_em_balance.py
@@ -6,12 +6,13 @@ Strategy:
 3. Restore math em tags
 4. Verify balance
 """
+
 import os
 import re
 
 
 def fix_file(path):
-    with open(path, 'r', encoding='utf-8') as f:
+    with open(path, "r", encoding="utf-8") as f:
         content = f.read()
 
     original = content
@@ -19,50 +20,45 @@ def fix_file(path):
     # Step 1: Extract and protect all <em class="math">...</em> pairs
     # Replace them with unique placeholders
     math_spans = []
+
     def protect_math(m):
         math_spans.append(m.group(0))
-        return f'__MATH_PLACEHOLDER_{len(math_spans)-1}__'
+        return f"__MATH_PLACEHOLDER_{len(math_spans)-1}__"
 
     content = re.sub(
-        r'<em class="math">(.*?)</em>',
-        protect_math,
-        content,
-        flags=re.DOTALL
+        r'<em class="math">(.*?)</em>', protect_math, content, flags=re.DOTALL
     )
 
     # Step 2: Remove ALL remaining <em> and </em> tags (broken italic from markdown)
-    plain_em_removed = content.count('<em>') + content.count('<em ')
-    content = re.sub(r'<em(?:\s[^>]*)?>',  '', content)  # remove <em> and <em ...>
-    content = content.replace('</em>', '')  # remove orphaned </em>
+    plain_em_removed = content.count("<em>") + content.count("<em ")
+    content = re.sub(r"<em(?:\s[^>]*)?>", "", content)  # remove <em> and <em ...>
+    content = content.replace("</em>", "")  # remove orphaned </em>
 
     # Step 3: Restore math em tags
     for i, span in enumerate(math_spans):
-        content = content.replace(f'__MATH_PLACEHOLDER_{i}__', span)
+        content = content.replace(f"__MATH_PLACEHOLDER_{i}__", span)
 
     # Step 4: Fix any <em class="math"> that contain * not escaped as ^*
     # Pattern: <em class="math">...*</em> where * should be ^*
     def fix_star_in_math(m):
         inner = m.group(1)
         # If it ends with * (not ^*), fix it
-        if inner.endswith('*') and not inner.endswith('^*'):
-            inner = inner[:-1] + '^*'
+        if inner.endswith("*") and not inner.endswith("^*"):
+            inner = inner[:-1] + "^*"
         # Fix internal unescaped * that aren't ^*
         # But be careful: * in \text{...} is fine
-        return '<em class="math">' + inner + '</em>'
+        return '<em class="math">' + inner + "</em>"
 
     content = re.sub(
-        r'<em class="math">(.*?)</em>',
-        fix_star_in_math,
-        content,
-        flags=re.DOTALL
+        r'<em class="math">(.*?)</em>', fix_star_in_math, content, flags=re.DOTALL
     )
 
     # Step 5: Verify balance
-    opens = content.count('<em')
-    closes = content.count('</em>')
+    opens = content.count("<em")
+    closes = content.count("</em>")
 
     if content != original:
-        with open(path, 'w', encoding='utf-8') as f:
+        with open(path, "w", encoding="utf-8") as f:
             f.write(content)
         return True, plain_em_removed, opens, closes
     return False, 0, opens, closes
@@ -72,28 +68,39 @@ total_fixed = 0
 total_em_removed = 0
 imbalanced = []
 
-for book in ['book', 'geometric-reasoning', 'geometric-economics', 'geometric-law',
-             'geometric-cognition', 'geometric-communication', 'geometric-medicine']:
-    book_dir = os.path.join('docs', book)
+for book in [
+    "book",
+    "geometric-reasoning",
+    "geometric-economics",
+    "geometric-law",
+    "geometric-cognition",
+    "geometric-communication",
+    "geometric-medicine",
+]:
+    book_dir = os.path.join("docs", book)
     if not os.path.isdir(book_dir):
         continue
     for fn in sorted(os.listdir(book_dir)):
-        if not fn.endswith('.html') or fn == 'index.html':
+        if not fn.endswith(".html") or fn == "index.html":
             continue
         path = os.path.join(book_dir, fn)
         fixed, em_removed, opens, closes = fix_file(path)
         if fixed:
             total_fixed += 1
             total_em_removed += em_removed
-            status = 'OK' if opens == closes else f'IMBALANCED ({opens} opens, {closes} closes)'
+            status = (
+                "OK"
+                if opens == closes
+                else f"IMBALANCED ({opens} opens, {closes} closes)"
+            )
             if opens != closes:
-                imbalanced.append(f'{book}/{fn}')
-            print(f'  {book}/{fn}: removed {em_removed} plain <em>, {status}')
+                imbalanced.append(f"{book}/{fn}")
+            print(f"  {book}/{fn}: removed {em_removed} plain <em>, {status}")
 
-print(f'\nTotal: {total_fixed} files fixed, {total_em_removed} plain <em> tags removed')
+print(f"\nTotal: {total_fixed} files fixed, {total_em_removed} plain <em> tags removed")
 if imbalanced:
-    print(f'Still imbalanced ({len(imbalanced)}):')
+    print(f"Still imbalanced ({len(imbalanced)}):")
     for f in imbalanced:
-        print(f'  {f}')
+        print(f"  {f}")
 else:
-    print('All files balanced!')
+    print("All files balanced!")

--- a/fix_all_math.py
+++ b/fix_all_math.py
@@ -8,62 +8,138 @@ KATEX_HEAD = '  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@
 KATEX_BODY = '<script>\ndocument.addEventListener("DOMContentLoaded", function() {\n  renderMathInElement(document.body, {\n    delimiters: [\n      {left: "$$", right: "$$", display: true},\n      {left: "$", right: "$", display: false}\n    ],\n    throwOnError: false\n  });\n});\n</script>'
 
 LATEX_CMDS = [
-    'alpha', 'beta', 'gamma', 'delta', 'epsilon', 'theta', 'lambda',
-    'mu', 'sigma', 'omega', 'phi', 'psi', 'rho', 'tau', 'pi', 'eta',
-    'nu', 'kappa', 'chi', 'Sigma', 'Omega', 'Delta', 'Gamma', 'Lambda',
-    'Phi', 'Psi', 'Pi', 'Theta',
-    'mathbf', 'mathcal', 'mathbb', 'mathrm', 'text', 'textbf',
-    'frac', 'sqrt', 'sum', 'int', 'prod', 'partial', 'nabla',
-    'infty', 'times', 'cdot', 'ldots', 'dots', 'cdots',
-    'leq', 'geq', 'neq', 'approx', 'equiv', 'sim',
-    'left', 'right', 'langle', 'rangle',
-    'begin', 'end', 'quad', 'qquad',
-    'vec', 'hat', 'bar', 'tilde', 'overline',
-    'forall', 'exists', 'notin', 'subset', 'cup', 'cap',
-    'to', 'rightarrow', 'leftarrow', 'mapsto',
-    'log', 'max', 'min', 'arg', 'sup', 'inf', 'lim',
+    "alpha",
+    "beta",
+    "gamma",
+    "delta",
+    "epsilon",
+    "theta",
+    "lambda",
+    "mu",
+    "sigma",
+    "omega",
+    "phi",
+    "psi",
+    "rho",
+    "tau",
+    "pi",
+    "eta",
+    "nu",
+    "kappa",
+    "chi",
+    "Sigma",
+    "Omega",
+    "Delta",
+    "Gamma",
+    "Lambda",
+    "Phi",
+    "Psi",
+    "Pi",
+    "Theta",
+    "mathbf",
+    "mathcal",
+    "mathbb",
+    "mathrm",
+    "text",
+    "textbf",
+    "frac",
+    "sqrt",
+    "sum",
+    "int",
+    "prod",
+    "partial",
+    "nabla",
+    "infty",
+    "times",
+    "cdot",
+    "ldots",
+    "dots",
+    "cdots",
+    "leq",
+    "geq",
+    "neq",
+    "approx",
+    "equiv",
+    "sim",
+    "left",
+    "right",
+    "langle",
+    "rangle",
+    "begin",
+    "end",
+    "quad",
+    "qquad",
+    "vec",
+    "hat",
+    "bar",
+    "tilde",
+    "overline",
+    "forall",
+    "exists",
+    "notin",
+    "subset",
+    "cup",
+    "cap",
+    "to",
+    "rightarrow",
+    "leftarrow",
+    "mapsto",
+    "log",
+    "max",
+    "min",
+    "arg",
+    "sup",
+    "inf",
+    "lim",
 ]
 
-docs = 'docs'
+docs = "docs"
 count = 0
 
-for book in ['book', 'geometric-reasoning', 'geometric-economics', 'geometric-law',
-             'geometric-cognition', 'geometric-communication', 'geometric-medicine']:
+for book in [
+    "book",
+    "geometric-reasoning",
+    "geometric-economics",
+    "geometric-law",
+    "geometric-cognition",
+    "geometric-communication",
+    "geometric-medicine",
+]:
     book_dir = os.path.join(docs, book)
     if not os.path.isdir(book_dir):
         continue
     for fn in sorted(os.listdir(book_dir)):
-        if not fn.endswith('.html') or fn == 'index.html':
+        if not fn.endswith(".html") or fn == "index.html":
             continue
         path = os.path.join(book_dir, fn)
-        with open(path, 'r', encoding='utf-8') as f:
+        with open(path, "r", encoding="utf-8") as f:
             content = f.read()
 
         modified = False
 
         # 1. Add KaTeX CDN if not present
-        if 'katex' not in content.lower():
-            content = content.replace('</head>', KATEX_HEAD + '\n</head>')
-            content = content.replace('</body>', KATEX_BODY + '\n</body>')
+        if "katex" not in content.lower():
+            content = content.replace("</head>", KATEX_HEAD + "\n</head>")
+            content = content.replace("</body>", KATEX_BODY + "\n</body>")
             modified = True
 
         # 2. Fix double-escaped LaTeX commands
         for cmd in LATEX_CMDS:
-            double = '\\\\' + cmd
-            single = '\\' + cmd
+            double = "\\\\" + cmd
+            single = "\\" + cmd
             if double in content:
                 content = content.replace(double, single)
                 modified = True
 
         # 3. Fix escaped underscores and carets in math
-        if '\\_' in content:
-            content = content.replace('\\_', '_')
+        if "\\_" in content:
+            content = content.replace("\\_", "_")
             modified = True
 
         if modified:
-            with open(path, 'w', encoding='utf-8') as f:
+            with open(path, "w", encoding="utf-8") as f:
                 f.write(content)
             count += 1
-            print(f'  Fixed: {book}/{fn}')
+            print(f"  Fixed: {book}/{fn}")
 
-print(f'\nTotal: {count} files fixed')
+print(f"\nTotal: {count} files fixed")

--- a/fix_double_escape.py
+++ b/fix_double_escape.py
@@ -4,8 +4,9 @@ Replaces \\\\ with \\ inside em.math and display-math elements."""
 import os
 import re
 
+
 def fix_file(path):
-    with open(path, 'r', encoding='utf-8') as f:
+    with open(path, "r", encoding="utf-8") as f:
         content = f.read()
 
     original = content
@@ -20,49 +21,51 @@ def fix_file(path):
         text = match.group(1)
         # Replace \\\\ with \\ (double-escaped to single-escaped)
         # In the file, \\beta appears as the literal characters \ \ b e t a
-        text = text.replace('\\\\', '\\')
+        text = text.replace("\\\\", "\\")
         # Also fix escaped underscores
-        text = text.replace('\\_', '_')
-        return '<em class="math">' + text + '</em>'
+        text = text.replace("\\_", "_")
+        return '<em class="math">' + text + "</em>"
 
     content = re.sub(
-        r'<em class="math">(.*?)</em>',
-        fix_math_content,
-        content,
-        flags=re.DOTALL
+        r'<em class="math">(.*?)</em>', fix_math_content, content, flags=re.DOTALL
     )
 
     # Also fix display math
     def fix_display_math(match):
         text = match.group(1)
-        text = text.replace('\\\\', '\\')
-        text = text.replace('\\_', '_')
-        return '<p class="display-math">' + text + '</p>'
+        text = text.replace("\\\\", "\\")
+        text = text.replace("\\_", "_")
+        return '<p class="display-math">' + text + "</p>"
 
     content = re.sub(
-        r'<p class="display-math">(.*?)</p>',
-        fix_display_math,
-        content,
-        flags=re.DOTALL
+        r'<p class="display-math">(.*?)</p>', fix_display_math, content, flags=re.DOTALL
     )
 
     if content != original:
-        with open(path, 'w', encoding='utf-8') as f:
+        with open(path, "w", encoding="utf-8") as f:
             f.write(content)
         return True
     return False
 
+
 count = 0
-for book in ['book', 'geometric-reasoning', 'geometric-economics', 'geometric-law',
-             'geometric-cognition', 'geometric-communication', 'geometric-medicine']:
-    book_dir = os.path.join('docs', book)
+for book in [
+    "book",
+    "geometric-reasoning",
+    "geometric-economics",
+    "geometric-law",
+    "geometric-cognition",
+    "geometric-communication",
+    "geometric-medicine",
+]:
+    book_dir = os.path.join("docs", book)
     if not os.path.isdir(book_dir):
         continue
     for fn in sorted(os.listdir(book_dir)):
-        if not fn.endswith('.html') or fn == 'index.html':
+        if not fn.endswith(".html") or fn == "index.html":
             continue
         if fix_file(os.path.join(book_dir, fn)):
             count += 1
-            print(f'  Fixed: {book}/{fn}')
+            print(f"  Fixed: {book}/{fn}")
 
-print(f'\nTotal: {count} files fixed')
+print(f"\nTotal: {count} files fixed")

--- a/fix_html_rendering.py
+++ b/fix_html_rendering.py
@@ -11,14 +11,14 @@ to HTML math markup.
 This script processes all chapter-*.html files in the geometric-* book directories.
 """
 
-import re
-import os
 import glob
-
+import os
+import re
 
 # ============================================================
 # Problem 1: Fix A* rendering issues
 # ============================================================
+
 
 def fix_astar_rendering(html: str) -> str:
     r"""Fix broken A* rendering caused by markdown asterisk -> <em> conversion.
@@ -28,34 +28,34 @@ def fix_astar_rendering(html: str) -> str:
     Phase 2: Fix A<em>...A</em> pairs with proper em tag matching
     Phase 3: Fix remaining orphaned em tags from phase 2
     """
-    lines = html.split('\n')
+    lines = html.split("\n")
     fixed_lines = []
     for line in lines:
         fixed_lines.append(fix_astar_in_line(line))
-    return '\n'.join(fixed_lines)
+    return "\n".join(fixed_lines)
 
 
 def fix_astar_in_line(line: str) -> str:
     """Fix A* rendering issues in a single line."""
 
-    if '<em' not in line:
+    if "<em" not in line:
         return line
 
     # Phase 1: Fix simple caret-based patterns
     # These are unambiguous and safe to fix.
 
     # X^<em></em> -> X* (empty em from X^*)
-    line = re.sub(r'(\w)\^<em></em>', r'\1*', line)
+    line = re.sub(r"(\w)\^<em></em>", r"\1*", line)
 
     # X^</em> -> X* (premature em close from X^* inside math)
-    line = re.sub(r'(\w)\^</em>', r'\1*', line)
+    line = re.sub(r"(\w)\^</em>", r"\1*", line)
 
     # X^<em> -> X* (em opened by * after ^, NOT class= attributes)
-    line = re.sub(r'(\w)\^<em>(?!\s*class)', r'\1*', line)
+    line = re.sub(r"(\w)\^<em>(?!\s*class)", r"\1*", line)
 
     # g^<em> and g^</em> patterns
-    line = re.sub(r'g\^<em>(?!\s*class)', 'g*', line)
-    line = re.sub(r'g\^</em>', 'g*', line)
+    line = re.sub(r"g\^<em>(?!\s*class)", "g*", line)
+    line = re.sub(r"g\^</em>", "g*", line)
 
     # Phase 2: Fix A<em>...A</em> and similar paired patterns
     # Use stack-based approach to find matching em pairs
@@ -87,24 +87,24 @@ def fix_paired_astar_em(line: str) -> str:
     changed = True
     while changed:
         changed = False
-        tokens = tokenize_em_tags(''.join(tokens))
+        tokens = tokenize_em_tags("".join(tokens))
 
         for i, token in enumerate(tokens):
-            if token != '<em>':
+            if token != "<em>":
                 continue
 
             # Check if preceded by 'A' at end of previous text token
             if i == 0:
                 continue
 
-            prev_text = tokens[i-1]
+            prev_text = tokens[i - 1]
             if not prev_text:
                 continue
 
             # Check: is this A<em> in non-math context?
             # The A must be preceded by non-letter (word boundary)
             # and NOT preceded by '="math">' or similar math context
-            if not prev_text.endswith('A'):
+            if not prev_text.endswith("A"):
                 continue
 
             # Check the character before A
@@ -122,46 +122,46 @@ def fix_paired_astar_em(line: str) -> str:
             # and find+remove the matching </em>
 
             # Replace A<em> with A*
-            tokens[i-1] = prev_text[:-1] + 'A*'  # Remove the A, add A*
+            tokens[i - 1] = prev_text[:-1] + "A*"  # Remove the A, add A*
             # But wait, prev_text ends with A, so just replace the token
-            tokens[i] = ''  # Remove the <em>
+            tokens[i] = ""  # Remove the <em>
 
             # Find the matching </em>
             # Track em nesting depth to find the correct close
             depth = 1
-            for j in range(i+1, len(tokens)):
-                if tokens[j] == '<em>':
+            for j in range(i + 1, len(tokens)):
+                if tokens[j] == "<em>":
                     depth += 1
-                elif tokens[j] == '</em>':
+                elif tokens[j] == "</em>":
                     depth -= 1
                     if depth == 0:
                         # This is the matching </em>
                         # Check context: is this A</em> (another A*)?
-                        if j > 0 and tokens[j-1].endswith('A'):
+                        if j > 0 and tokens[j - 1].endswith("A"):
                             # Another A* reference
-                            prev = tokens[j-1]
+                            prev = tokens[j - 1]
                             if len(prev) > 1:
                                 char_before = prev[-2]
                                 if not char_before.isalpha():
-                                    tokens[j-1] = prev[:-1] + 'A*'
-                                    tokens[j] = ''
+                                    tokens[j - 1] = prev[:-1] + "A*"
+                                    tokens[j] = ""
                                     break
                             else:
                                 # prev is just 'A'
-                                tokens[j-1] = 'A*'
-                                tokens[j] = ''
+                                tokens[j - 1] = "A*"
+                                tokens[j] = ""
                                 break
 
                         # Not A</em> - this </em> was closing
                         # a legitimate italic that got consumed.
                         # We need to remove it.
-                        tokens[j] = ''
+                        tokens[j] = ""
                         break
 
             changed = True
             break  # Restart the loop after making changes
 
-    return ''.join(tokens)
+    return "".join(tokens)
 
 
 def tokenize_em_tags(html: str) -> list:
@@ -185,37 +185,41 @@ def tokenize_em_tags(html: str) -> list:
         # <em> must be followed by > immediately (no space/class)
         # </em> is always </em>
 
-        if html[pos:pos+5] == '</em>':
+        if html[pos : pos + 5] == "</em>":
             # Check if this is really a close for a bare em or a math em
             # We tokenize all </em> - the matching logic handles context
             if tokens and isinstance(tokens[-1], str):
                 pass  # previous token is text, good
             else:
-                tokens.append('')  # empty text before
-            tokens.append('</em>')
+                tokens.append("")  # empty text before
+            tokens.append("</em>")
             pos += 5
             continue
 
-        if html[pos:pos+4] == '<em>':
+        if html[pos : pos + 4] == "<em>":
             # Bare <em> tag - tokenize it
             if not tokens:
-                tokens.append('')  # empty text before
-            elif tokens[-1] in ('<em>', '</em>'):
-                tokens.append('')  # empty text between tags
-            tokens.append('<em>')
+                tokens.append("")  # empty text before
+            elif tokens[-1] in ("<em>", "</em>"):
+                tokens.append("")  # empty text between tags
+            tokens.append("<em>")
             pos += 4
             continue
 
-        if html[pos:pos+4] == '<em ':
+        if html[pos : pos + 4] == "<em ":
             # <em with attributes like <em class="math">
             # Don't tokenize - keep as text
             # Find the closing >
-            end = html.find('>', pos)
+            end = html.find(">", pos)
             if end == -1:
                 end = len(html)
             # Include everything up to and including >
-            chunk = html[pos:end+1]
-            if tokens and isinstance(tokens[-1], str) and tokens[-1] not in ('<em>', '</em>'):
+            chunk = html[pos : end + 1]
+            if (
+                tokens
+                and isinstance(tokens[-1], str)
+                and tokens[-1] not in ("<em>", "</em>")
+            ):
                 tokens[-1] += chunk
             else:
                 tokens.append(chunk)
@@ -223,7 +227,7 @@ def tokenize_em_tags(html: str) -> list:
             continue
 
         # Regular character - add to current text token
-        if not tokens or tokens[-1] in ('<em>', '</em>'):
+        if not tokens or tokens[-1] in ("<em>", "</em>"):
             tokens.append(html[pos])
         else:
             tokens[-1] += html[pos]
@@ -236,280 +240,333 @@ def tokenize_em_tags(html: str) -> list:
 # Problem 2: Convert raw LaTeX to HTML
 # ============================================================
 
+
 def convert_latex_to_html(text: str) -> str:
     r"""Convert LaTeX math expressions to HTML."""
     result = text
 
     # \mathbf{X} -> <strong>X</strong>
-    result = re.sub(r'\\mathbf\{([^}]+)\}', r'<strong>\1</strong>', result)
+    result = re.sub(r"\\mathbf\{([^}]+)\}", r"<strong>\1</strong>", result)
 
     # \mathcal{X} -> unicode script letter
     mathcal_map = {
-        'A': '\U0001D49C', 'B': '\U0001D49D', 'C': '\U0001D49E',
-        'D': '\U0001D49F', 'E': '\U0001D4A0', 'F': '\U0001D4A1',
-        'G': '\U0001D4A2', 'H': '\u210B', 'I': '\u2110',
-        'J': '\U0001D4A5', 'K': '\U0001D4A6', 'L': '\u2112',
-        'M': '\u2133', 'N': '\U0001D4A9', 'O': '\U0001D4AA',
-        'P': '\U0001D4AB', 'Q': '\U0001D4AC', 'R': '\u211B',
-        'S': '\U0001D4AE', 'T': '\U0001D4AF', 'U': '\U0001D4B0',
-        'V': '\U0001D4B1', 'W': '\U0001D4B2', 'X': '\U0001D4B3',
-        'Y': '\U0001D4B4', 'Z': '\U0001D4B5',
+        "A": "\U0001d49c",
+        "B": "\U0001d49d",
+        "C": "\U0001d49e",
+        "D": "\U0001d49f",
+        "E": "\U0001d4a0",
+        "F": "\U0001d4a1",
+        "G": "\U0001d4a2",
+        "H": "\u210b",
+        "I": "\u2110",
+        "J": "\U0001d4a5",
+        "K": "\U0001d4a6",
+        "L": "\u2112",
+        "M": "\u2133",
+        "N": "\U0001d4a9",
+        "O": "\U0001d4aa",
+        "P": "\U0001d4ab",
+        "Q": "\U0001d4ac",
+        "R": "\u211b",
+        "S": "\U0001d4ae",
+        "T": "\U0001d4af",
+        "U": "\U0001d4b0",
+        "V": "\U0001d4b1",
+        "W": "\U0001d4b2",
+        "X": "\U0001d4b3",
+        "Y": "\U0001d4b4",
+        "Z": "\U0001d4b5",
     }
+
     def replace_mathcal(m):
         return mathcal_map.get(m.group(1), m.group(1))
-    result = re.sub(r'\\mathcal\{([^}]+)\}', replace_mathcal, result)
+
+    result = re.sub(r"\\mathcal\{([^}]+)\}", replace_mathcal, result)
 
     # \mathbb{R} -> unicode double-struck
     mathbb_map = {
-        'R': '\u211D', 'N': '\u2115', 'Z': '\u2124',
-        'Q': '\u211A', 'C': '\u2102',
+        "R": "\u211d",
+        "N": "\u2115",
+        "Z": "\u2124",
+        "Q": "\u211a",
+        "C": "\u2102",
     }
+
     def replace_mathbb(m):
         return mathbb_map.get(m.group(1), m.group(1))
-    result = re.sub(r'\\mathbb\{([^}]+)\}', replace_mathbb, result)
+
+    result = re.sub(r"\\mathbb\{([^}]+)\}", replace_mathbb, result)
 
     # \text{word} -> word
-    result = re.sub(r'\\text\{([^}]+)\}', r'\1', result)
+    result = re.sub(r"\\text\{([^}]+)\}", r"\1", result)
 
     # \operatorname{X} -> X
-    result = re.sub(r'\\operatorname\{([^}]+)\}', r'\1', result)
+    result = re.sub(r"\\operatorname\{([^}]+)\}", r"\1", result)
 
     # Symbol replacements (longest patterns first)
     symbol_replacements = [
-        ('\\Rightarrow', '\u21D2'),
-        ('\\Leftarrow', '\u21D0'),
-        ('\\Leftrightarrow', '\u21D4'),
-        ('\\rightarrow', '\u2192'),
-        ('\\leftarrow', '\u2190'),
-        ('\\leftrightarrow', '\u2194'),
-        ('\\mapsto', '\u21A6'),
-        ('\\implies', '\u27F9'),
-        ('\\iff', '\u27FA'),
-        ('\\varepsilon', '\u03B5'),
-        ('\\epsilon', '\u03B5'),
-        ('\\subseteq', '\u2286'),
-        ('\\supseteq', '\u2287'),
-        ('\\subset', '\u2282'),
-        ('\\supset', '\u2283'),
-        ('\\emptyset', '\u2205'),
-        ('\\notin', '\u2209'),
-        ('\\ldots', '\u2026'),
-        ('\\cdots', '\u22EF'),
-        ('\\cdot', '\u00B7'),
-        ('\\times', '\u00D7'),
-        ('\\leq', '\u2264'),
-        ('\\geq', '\u2265'),
-        ('\\neq', '\u2260'),
-        ('\\approx', '\u2248'),
-        ('\\infty', '\u221E'),
-        ('\\alpha', '\u03B1'),
-        ('\\beta', '\u03B2'),
-        ('\\gamma', '\u03B3'),
-        ('\\delta', '\u03B4'),
-        ('\\zeta', '\u03B6'),
-        ('\\eta', '\u03B7'),
-        ('\\theta', '\u03B8'),
-        ('\\iota', '\u03B9'),
-        ('\\kappa', '\u03BA'),
-        ('\\lambda', '\u03BB'),
-        ('\\mu', '\u03BC'),
-        ('\\nu', '\u03BD'),
-        ('\\xi', '\u03BE'),
-        ('\\pi', '\u03C0'),
-        ('\\rho', '\u03C1'),
-        ('\\sigma', '\u03C3'),
-        ('\\tau', '\u03C4'),
-        ('\\upsilon', '\u03C5'),
-        ('\\phi', '\u03C6'),
-        ('\\chi', '\u03C7'),
-        ('\\psi', '\u03C8'),
-        ('\\omega', '\u03C9'),
-        ('\\Gamma', '\u0393'),
-        ('\\Delta', '\u0394'),
-        ('\\Theta', '\u0398'),
-        ('\\Lambda', '\u039B'),
-        ('\\Xi', '\u039E'),
-        ('\\Pi', '\u03A0'),
-        ('\\Sigma', '\u03A3'),
-        ('\\Phi', '\u03A6'),
-        ('\\Psi', '\u03A8'),
-        ('\\Omega', '\u03A9'),
-        ('\\sum', '\u2211'),
-        ('\\prod', '\u220F'),
-        ('\\int', '\u222B'),
-        ('\\partial', '\u2202'),
-        ('\\nabla', '\u2207'),
-        ('\\forall', '\u2200'),
-        ('\\exists', '\u2203'),
-        ('\\cup', '\u222A'),
-        ('\\cap', '\u2229'),
-        ('\\wedge', '\u2227'),
-        ('\\vee', '\u2228'),
-        ('\\neg', '\u00AC'),
-        ('\\in', '\u2208'),
-        ('\\to', '\u2192'),
-        ('\\ell', '\u2113'),
-        ('\\sim', '\u223C'),
-        ('\\gg', '\u226B'),
-        ('\\ll', '\u226A'),
-        ('\\mid', '|'),
-        ('\\varphi', '\u03C6'),
-        ('\\circ', '\u2218'),
-        ('\\oplus', '\u2295'),
-        ('\\succ', '\u227B'),
-        ('\\prec', '\u227A'),
-        ('\\langle', '\u27E8'),
-        ('\\rangle', '\u27E9'),
-        ('\\top', '\u22A4'),
-        ('\\bot', '\u22A5'),
-        ('\\pm', '\u00B1'),
-        ('\\mp', '\u2213'),
-        ('\\cong', '\u2245'),
-        ('\\propto', '\u221D'),
-        ('\\hookrightarrow', '\u21AA'),
-        ('\\setminus', '\u2216'),  # set minus
-        ('\\diamond', '\u25C7'),
-        ('\\triangle', '\u25B3'),
-        ('\\perp', '\u22A5'),
-        ('\\star', '\u22C6'),
-        ('\\bullet', '\u2022'),
-        ('\\not', '\u0338'),
-        ('\\degree', '\u00B0'),
-        ('\\oint', '\u222E'),
-        ('\\updownarrow', '\u2195'),
-        ('\\quad', '  '),
-        ('\\qquad', '    '),
+        ("\\Rightarrow", "\u21d2"),
+        ("\\Leftarrow", "\u21d0"),
+        ("\\Leftrightarrow", "\u21d4"),
+        ("\\rightarrow", "\u2192"),
+        ("\\leftarrow", "\u2190"),
+        ("\\leftrightarrow", "\u2194"),
+        ("\\mapsto", "\u21a6"),
+        ("\\implies", "\u27f9"),
+        ("\\iff", "\u27fa"),
+        ("\\varepsilon", "\u03b5"),
+        ("\\epsilon", "\u03b5"),
+        ("\\subseteq", "\u2286"),
+        ("\\supseteq", "\u2287"),
+        ("\\subset", "\u2282"),
+        ("\\supset", "\u2283"),
+        ("\\emptyset", "\u2205"),
+        ("\\notin", "\u2209"),
+        ("\\ldots", "\u2026"),
+        ("\\cdots", "\u22ef"),
+        ("\\cdot", "\u00b7"),
+        ("\\times", "\u00d7"),
+        ("\\leq", "\u2264"),
+        ("\\geq", "\u2265"),
+        ("\\neq", "\u2260"),
+        ("\\approx", "\u2248"),
+        ("\\infty", "\u221e"),
+        ("\\alpha", "\u03b1"),
+        ("\\beta", "\u03b2"),
+        ("\\gamma", "\u03b3"),
+        ("\\delta", "\u03b4"),
+        ("\\zeta", "\u03b6"),
+        ("\\eta", "\u03b7"),
+        ("\\theta", "\u03b8"),
+        ("\\iota", "\u03b9"),
+        ("\\kappa", "\u03ba"),
+        ("\\lambda", "\u03bb"),
+        ("\\mu", "\u03bc"),
+        ("\\nu", "\u03bd"),
+        ("\\xi", "\u03be"),
+        ("\\pi", "\u03c0"),
+        ("\\rho", "\u03c1"),
+        ("\\sigma", "\u03c3"),
+        ("\\tau", "\u03c4"),
+        ("\\upsilon", "\u03c5"),
+        ("\\phi", "\u03c6"),
+        ("\\chi", "\u03c7"),
+        ("\\psi", "\u03c8"),
+        ("\\omega", "\u03c9"),
+        ("\\Gamma", "\u0393"),
+        ("\\Delta", "\u0394"),
+        ("\\Theta", "\u0398"),
+        ("\\Lambda", "\u039b"),
+        ("\\Xi", "\u039e"),
+        ("\\Pi", "\u03a0"),
+        ("\\Sigma", "\u03a3"),
+        ("\\Phi", "\u03a6"),
+        ("\\Psi", "\u03a8"),
+        ("\\Omega", "\u03a9"),
+        ("\\sum", "\u2211"),
+        ("\\prod", "\u220f"),
+        ("\\int", "\u222b"),
+        ("\\partial", "\u2202"),
+        ("\\nabla", "\u2207"),
+        ("\\forall", "\u2200"),
+        ("\\exists", "\u2203"),
+        ("\\cup", "\u222a"),
+        ("\\cap", "\u2229"),
+        ("\\wedge", "\u2227"),
+        ("\\vee", "\u2228"),
+        ("\\neg", "\u00ac"),
+        ("\\in", "\u2208"),
+        ("\\to", "\u2192"),
+        ("\\ell", "\u2113"),
+        ("\\sim", "\u223c"),
+        ("\\gg", "\u226b"),
+        ("\\ll", "\u226a"),
+        ("\\mid", "|"),
+        ("\\varphi", "\u03c6"),
+        ("\\circ", "\u2218"),
+        ("\\oplus", "\u2295"),
+        ("\\succ", "\u227b"),
+        ("\\prec", "\u227a"),
+        ("\\langle", "\u27e8"),
+        ("\\rangle", "\u27e9"),
+        ("\\top", "\u22a4"),
+        ("\\bot", "\u22a5"),
+        ("\\pm", "\u00b1"),
+        ("\\mp", "\u2213"),
+        ("\\cong", "\u2245"),
+        ("\\propto", "\u221d"),
+        ("\\hookrightarrow", "\u21aa"),
+        ("\\setminus", "\u2216"),  # set minus
+        ("\\diamond", "\u25c7"),
+        ("\\triangle", "\u25b3"),
+        ("\\perp", "\u22a5"),
+        ("\\star", "\u22c6"),
+        ("\\bullet", "\u2022"),
+        ("\\not", "\u0338"),
+        ("\\degree", "\u00b0"),
+        ("\\oint", "\u222e"),
+        ("\\updownarrow", "\u2195"),
+        ("\\quad", "  "),
+        ("\\qquad", "    "),
     ]
 
     for latex_cmd, replacement in symbol_replacements:
         escaped = re.escape(latex_cmd)
-        result = re.sub(escaped + r'(?![a-zA-Z])', replacement, result)
+        result = re.sub(escaped + r"(?![a-zA-Z])", replacement, result)
 
     # Small spacing - always convert, no lookahead needed
-    result = result.replace('\\,', ' ')
-    result = result.replace('\\;', ' ')
-    result = result.replace('\\!', '')
-    result = result.replace('\\%', '%')
-    result = result.replace('\\_', '_')
-    result = result.replace('\\#', '#')
-    result = result.replace('\\&', '&')
+    result = result.replace("\\,", " ")
+    result = result.replace("\\;", " ")
+    result = result.replace("\\!", "")
+    result = result.replace("\\%", "%")
+    result = result.replace("\\_", "_")
+    result = result.replace("\\#", "#")
+    result = result.replace("\\&", "&")
 
     # \sqrt{x}
     def replace_sqrt(m):
         c = m.group(1)
-        return f'\u221A{c}' if len(c) == 1 else f'\u221A({c})'
-    result = re.sub(r'\\sqrt\{([^}]+)\}', replace_sqrt, result)
+        return f"\u221a{c}" if len(c) == 1 else f"\u221a({c})"
+
+    result = re.sub(r"\\sqrt\{([^}]+)\}", replace_sqrt, result)
 
     # \frac{a}{b} - handle nested braces and HTML content
     def replace_frac(m):
-        return f'({m.group(1)})/({m.group(2)})'
+        return f"({m.group(1)})/({m.group(2)})"
+
     # Try simple non-nested first
-    result = re.sub(r'\\frac\{([^}]+)\}\{([^}]+)\}', replace_frac, result)
+    result = re.sub(r"\\frac\{([^}]+)\}\{([^}]+)\}", replace_frac, result)
     # Also handle cases where braces contain HTML tags (which have > and < but no })
     # Match \frac{ ... }{ ... } more greedily when content has HTML
-    result = re.sub(r'\\frac\{(.+?)\}\{(.+?)\}', replace_frac, result)
+    result = re.sub(r"\\frac\{(.+?)\}\{(.+?)\}", replace_frac, result)
 
     # \binom{n}{k}
-    result = re.sub(r'\\binom\{([^}]+)\}\{([^}]+)\}', r'C(\1,\2)', result)
-    result = re.sub(r'\\binom\{(.+?)\}\{(.+?)\}', r'C(\1,\2)', result)
+    result = re.sub(r"\\binom\{([^}]+)\}\{([^}]+)\}", r"C(\1,\2)", result)
+    result = re.sub(r"\\binom\{(.+?)\}\{(.+?)\}", r"C(\1,\2)", result)
 
     # \xrightarrow{x}
-    result = re.sub(r'\\xrightarrow\{([^}]+)\}',
-                     lambda m: '--' + m.group(1) + '\u2192', result)
+    result = re.sub(
+        r"\\xrightarrow\{([^}]+)\}", lambda m: "--" + m.group(1) + "\u2192", result
+    )
 
     # \mathrm{X} -> X (upright text in math)
-    result = re.sub(r'\\mathrm\{([^}]+)\}', r'\1', result)
+    result = re.sub(r"\\mathrm\{([^}]+)\}", r"\1", result)
 
     # \mathfrak{X} -> X
-    result = re.sub(r'\\mathfrak\{([^}]+)\}', r'\1', result)
+    result = re.sub(r"\\mathfrak\{([^}]+)\}", r"\1", result)
 
     # \vec{x} -> x with combining arrow
-    result = re.sub(r'\\vec\{([^}]+)\}', lambda m: m.group(1) + '\u20D7', result)
+    result = re.sub(r"\\vec\{([^}]+)\}", lambda m: m.group(1) + "\u20d7", result)
 
     # \underbrace{x}_{text} -> x (simplified)
-    result = re.sub(r'\\underbrace\{([^}]+)\}', r'\1', result)
+    result = re.sub(r"\\underbrace\{([^}]+)\}", r"\1", result)
 
     # \tfrac{a}{b} -> (a)/(b) (text-style fraction)
-    result = re.sub(r'\\tfrac\{([^}]+)\}\{([^}]+)\}', r'(\1)/(\2)', result)
+    result = re.sub(r"\\tfrac\{([^}]+)\}\{([^}]+)\}", r"(\1)/(\2)", result)
 
     # \xleftarrow{x} -> <--x
-    result = re.sub(r'\\xleftarrow\{([^}]+)\}',
-                     lambda m: '\u2190' + m.group(1) + '--', result)
+    result = re.sub(
+        r"\\xleftarrow\{([^}]+)\}", lambda m: "\u2190" + m.group(1) + "--", result
+    )
 
     # \xleftrightarrow{x} -> <--x-->
-    result = re.sub(r'\\xleftrightarrow\{([^}]+)\}',
-                     lambda m: '\u2194' + m.group(1), result)
+    result = re.sub(
+        r"\\xleftrightarrow\{([^}]+)\}", lambda m: "\u2194" + m.group(1), result
+    )
 
     # \scriptstyle -> (ignore, just remove)
-    result = result.replace('\\scriptstyle', '')
+    result = result.replace("\\scriptstyle", "")
 
     # Math functions
-    for func in ['log', 'ln', 'exp', 'sin', 'cos', 'tan', 'arccos',
-                  'arcsin', 'arctan', 'arctanh', 'tanh', 'sinh', 'cosh',
-                  'max', 'min', 'sup', 'inf', 'lim', 'det', 'dim',
-                  'ker', 'arg', 'argmin', 'argmax', 'Pr']:
-        result = re.sub(r'\\' + func + r'(?![a-zA-Z])', func, result)
+    for func in [
+        "log",
+        "ln",
+        "exp",
+        "sin",
+        "cos",
+        "tan",
+        "arccos",
+        "arcsin",
+        "arctan",
+        "arctanh",
+        "tanh",
+        "sinh",
+        "cosh",
+        "max",
+        "min",
+        "sup",
+        "inf",
+        "lim",
+        "det",
+        "dim",
+        "ker",
+        "arg",
+        "argmin",
+        "argmax",
+        "Pr",
+    ]:
+        result = re.sub(r"\\" + func + r"(?![a-zA-Z])", func, result)
 
     # Accents
-    result = re.sub(r'\\dot\{([^}]+)\}', lambda m: m.group(1) + '\u0307', result)
-    result = re.sub(r'\\ddot\{([^}]+)\}', lambda m: m.group(1) + '\u0308', result)
-    result = re.sub(r'\\bar\{([^}]+)\}', lambda m: m.group(1) + '\u0304', result)
-    result = re.sub(r'\\hat\{([^}]+)\}', lambda m: m.group(1) + '\u0302', result)
-    result = re.sub(r'\\tilde\{([^}]+)\}', lambda m: m.group(1) + '\u0303', result)
-    result = re.sub(r'\\overline\{([^}]+)\}', lambda m: m.group(1) + '\u0305', result)
+    result = re.sub(r"\\dot\{([^}]+)\}", lambda m: m.group(1) + "\u0307", result)
+    result = re.sub(r"\\ddot\{([^}]+)\}", lambda m: m.group(1) + "\u0308", result)
+    result = re.sub(r"\\bar\{([^}]+)\}", lambda m: m.group(1) + "\u0304", result)
+    result = re.sub(r"\\hat\{([^}]+)\}", lambda m: m.group(1) + "\u0302", result)
+    result = re.sub(r"\\tilde\{([^}]+)\}", lambda m: m.group(1) + "\u0303", result)
+    result = re.sub(r"\\overline\{([^}]+)\}", lambda m: m.group(1) + "\u0305", result)
 
     # Subscripts and superscripts (braced)
-    result = re.sub(r'_\{([^}]+)\}', r'<sub>\1</sub>', result)
-    result = re.sub(r'\^\{([^}]+)\}', r'<sup>\1</sup>', result)
+    result = re.sub(r"_\{([^}]+)\}", r"<sub>\1</sub>", result)
+    result = re.sub(r"\^\{([^}]+)\}", r"<sup>\1</sup>", result)
 
     # Single char sub/superscripts
-    result = re.sub(r'_([a-zA-Z0-9])(?![a-zA-Z0-9{])', r'<sub>\1</sub>', result)
-    result = re.sub(r'\^([a-zA-Z0-9])(?![a-zA-Z0-9{])', r'<sup>\1</sup>', result)
+    result = re.sub(r"_([a-zA-Z0-9])(?![a-zA-Z0-9{])", r"<sub>\1</sub>", result)
+    result = re.sub(r"\^([a-zA-Z0-9])(?![a-zA-Z0-9{])", r"<sup>\1</sup>", result)
 
     # Delimiters
-    result = re.sub(r'\\left\s*([(\[|])', r'\1', result)
-    result = re.sub(r'\\right\s*([)\]|])', r'\1', result)
-    result = result.replace('\\left', '')
-    result = result.replace('\\right', '')
+    result = re.sub(r"\\left\s*([(\[|])", r"\1", result)
+    result = re.sub(r"\\right\s*([)\]|])", r"\1", result)
+    result = result.replace("\\left", "")
+    result = result.replace("\\right", "")
 
     # Big delimiters
-    result = re.sub(r'\\[Bb]ig[lr]?\s*', '', result)
+    result = re.sub(r"\\[Bb]ig[lr]?\s*", "", result)
 
     # Norms
-    result = result.replace('\\lVert', '\u2016')
-    result = result.replace('\\rVert', '\u2016')
-    result = result.replace('\\|', '\u2016')
+    result = result.replace("\\lVert", "\u2016")
+    result = result.replace("\\rVert", "\u2016")
+    result = result.replace("\\|", "\u2016")
 
     # Escaped braces
-    result = result.replace('\\{', '{')
-    result = result.replace('\\}', '}')
+    result = result.replace("\\{", "{")
+    result = result.replace("\\}", "}")
 
     # Special symbols
-    result = result.replace('\\square', '\u25A1')
-    result = result.replace('\\S', '\u00A7')  # Section symbol
-    result = result.replace('\\equiv', '\u2261')
-    result = result.replace('\\downarrow', '\u2193')
-    result = result.replace('\\uparrow', '\u2191')
-    result = result.replace('\\nearrow', '\u2197')
-    result = result.replace('\\searrow', '\u2198')
-    result = result.replace('\\updownarrowopposite', '\u21C5')
+    result = result.replace("\\square", "\u25a1")
+    result = result.replace("\\S", "\u00a7")  # Section symbol
+    result = result.replace("\\equiv", "\u2261")
+    result = result.replace("\\downarrow", "\u2193")
+    result = result.replace("\\uparrow", "\u2191")
+    result = result.replace("\\nearrow", "\u2197")
+    result = result.replace("\\searrow", "\u2198")
+    result = result.replace("\\updownarrowopposite", "\u21c5")
 
     # \textbf{x} -> <strong>x</strong>
-    result = re.sub(r'\\textbf\{([^}]+)\}', r'<strong>\1</strong>', result)
+    result = re.sub(r"\\textbf\{([^}]+)\}", r"<strong>\1</strong>", result)
 
     # Environments - remove markers, they're already laid out
-    result = result.replace('\\begin{cases}', '')
-    result = result.replace('\\end{cases}', '')
-    result = result.replace('\\begin{pmatrix}', '')
-    result = result.replace('\\end{pmatrix}', '')
-    result = result.replace('\\begin{bmatrix}', '')
-    result = result.replace('\\end{bmatrix}', '')
-    result = result.replace('\\begin{array}{ccc}', '')
-    result = re.sub(r'\\begin\{array\}\{[^}]*\}', '', result)
-    result = result.replace('\\end{array}', '')
+    result = result.replace("\\begin{cases}", "")
+    result = result.replace("\\end{cases}", "")
+    result = result.replace("\\begin{pmatrix}", "")
+    result = result.replace("\\end{pmatrix}", "")
+    result = result.replace("\\begin{bmatrix}", "")
+    result = result.replace("\\end{bmatrix}", "")
+    result = result.replace("\\begin{array}{ccc}", "")
+    result = re.sub(r"\\begin\{array\}\{[^}]*\}", "", result)
+    result = result.replace("\\end{array}", "")
 
     # Line breaks
-    result = result.replace('\\\\', '<br>')
+    result = result.replace("\\\\", "<br>")
 
     return result
 
@@ -527,7 +584,7 @@ def convert_latex_in_existing_math_tags(html: str) -> str:
         r'<span class="math-block">(.+?)</span>',
         convert_math_block,
         html,
-        flags=re.DOTALL
+        flags=re.DOTALL,
     )
 
     # Convert LaTeX inside <em class="math">CONTENT</em>
@@ -535,7 +592,7 @@ def convert_latex_in_existing_math_tags(html: str) -> str:
     def convert_math_em(m):
         content = m.group(1)
         # Only convert if there's raw LaTeX to convert
-        if '\\' in content or ('_' in content and '<sub>' not in content):
+        if "\\" in content or ("_" in content and "<sub>" not in content):
             converted = convert_latex_to_html(content)
             return f'<em class="math">{converted}</em>'
         return m.group(0)  # No change
@@ -543,10 +600,7 @@ def convert_latex_in_existing_math_tags(html: str) -> str:
     # Run multiple passes to handle content that needs re-processing
     for _ in range(3):
         new_result = re.sub(
-            r'<em class="math">(.+?)</em>',
-            convert_math_em,
-            result,
-            flags=re.DOTALL
+            r'<em class="math">(.+?)</em>', convert_math_em, result, flags=re.DOTALL
         )
         if new_result == result:
             break
@@ -564,7 +618,7 @@ def find_and_convert_dollar_math(html: str) -> str:
         return f'<em class="math">{converted}</em>'
 
     # [$][$] matches literal $$ (not end-of-string anchor)
-    result = re.sub(r'[$][$](.+?)[$][$]', convert_display_math, html, flags=re.DOTALL)
+    result = re.sub(r"[$][$](.+?)[$][$]", convert_display_math, html, flags=re.DOTALL)
 
     def convert_inline_math(m):
         content = m.group(1).strip()
@@ -574,7 +628,9 @@ def find_and_convert_dollar_math(html: str) -> str:
         converted = convert_latex_to_html(content)
         return f'<em class="math">{converted}</em>'
 
-    result = re.sub(r'(?<![$])[$](?![$])(.+?)(?<![$])[$](?![$])', convert_inline_math, result)
+    result = re.sub(
+        r"(?<![$])[$](?![$])(.+?)(?<![$])[$](?![$])", convert_inline_math, result
+    )
 
     return result
 
@@ -583,10 +639,11 @@ def find_and_convert_dollar_math(html: str) -> str:
 # Main processing
 # ============================================================
 
+
 def process_file(filepath: str) -> tuple:
     """Process a single HTML file."""
 
-    with open(filepath, 'r', encoding='utf-8') as f:
+    with open(filepath, "r", encoding="utf-8") as f:
         original = f.read()
 
     html = original
@@ -611,7 +668,7 @@ def process_file(filepath: str) -> tuple:
     html = html_after_latex
 
     if html != original:
-        with open(filepath, 'w', encoding='utf-8') as f:
+        with open(filepath, "w", encoding="utf-8") as f:
             f.write(html)
         return True, changes
 
@@ -619,22 +676,22 @@ def process_file(filepath: str) -> tuple:
 
 
 def main():
-    base = os.path.join('C:', os.sep, 'source', 'erisml-lib', 'docs')
+    base = os.path.join("C:", os.sep, "source", "erisml-lib", "docs")
 
     directories = [
-        'geometric-reasoning',
-        'geometric-economics',
-        'geometric-law',
-        'geometric-cognition',
-        'geometric-communication',
-        'geometric-medicine',
+        "geometric-reasoning",
+        "geometric-economics",
+        "geometric-law",
+        "geometric-cognition",
+        "geometric-communication",
+        "geometric-medicine",
     ]
 
     total_files = 0
     changed_files = 0
 
     for dir_name in directories:
-        pattern = os.path.join(base, dir_name, 'chapter-*.html')
+        pattern = os.path.join(base, dir_name, "chapter-*.html")
         files = sorted(glob.glob(pattern))
 
         print(f"\n{'='*60}")
@@ -649,18 +706,18 @@ def main():
 
             if changed:
                 changed_files += 1
-                change_str = '; '.join(file_changes)
+                change_str = "; ".join(file_changes)
                 print(f"  FIXED: {filename} ({change_str})")
             else:
                 print(f"  ok:    {filename}")
 
     print(f"\n{'='*60}")
-    print(f"SUMMARY")
+    print("SUMMARY")
     print(f"{'='*60}")
     print(f"Total files processed: {total_files}")
     print(f"Files changed: {changed_files}")
     print(f"Files unchanged: {total_files - changed_files}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/fix_math.py
+++ b/fix_math.py
@@ -14,151 +14,162 @@ Strategy:
 - Insert them into the gaps in the HTML.
 """
 
-import sys, io, re, os, html
-sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+import html
+import io
+import os
+import re
+import sys
 
-from docx import Document
-import lxml.etree as ET
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
 
-BOOK_DIR = r'C:\source\erisml-lib\docs\book'
-DOCX_PATH = r'C:\source\erisml-lib\docs\papers\foundations\Geometric Ethics - The Mathematical Structure of Moral Reasoning - Bond - v1.14 - Mar 2026.docx'
+from docx import Document  # noqa: E402
 
-ns = {'m': 'http://schemas.openxmlformats.org/officeDocument/2006/math',
-      'w': 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'}
+BOOK_DIR = r"C:\source\erisml-lib\docs\book"
+DOCX_PATH = r"C:\source\erisml-lib\docs\papers\foundations\Geometric Ethics - The Mathematical Structure of Moral Reasoning - Bond - v1.14 - Mar 2026.docx"
+
+ns = {
+    "m": "http://schemas.openxmlformats.org/officeDocument/2006/math",
+    "w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+}
 
 
 def omath_to_unicode_inner(elem):
     parts = []
+
     def process(el):
-        tag = el.tag.split('}')[-1] if '}' in el.tag else el.tag
-        if tag == 't':
-            parts.append(el.text or '')
-        elif tag in ('r', 'e', 'sub', 'sup', 'num', 'den', 'deg'):
+        tag = el.tag.split("}")[-1] if "}" in el.tag else el.tag
+        if tag == "t":
+            parts.append(el.text or "")
+        elif tag in ("r", "e", "sub", "sup", "num", "den", "deg"):
             for child in el:
                 process(child)
-        elif tag.endswith('Pr'):
+        elif tag.endswith("Pr"):
             pass
         else:
             for child in el:
                 process(child)
+
     process(elem)
-    return ''.join(parts).strip()
+    return "".join(parts).strip()
 
 
 def omath_to_html(elem):
     """Convert Office MathML to inline HTML math notation."""
     parts = []
-    mns = 'http://schemas.openxmlformats.org/officeDocument/2006/math'
+    mns = "http://schemas.openxmlformats.org/officeDocument/2006/math"
 
     def process(el):
-        tag = el.tag.split('}')[-1] if '}' in el.tag else el.tag
-        if tag == 't':
-            t = el.text or ''
+        tag = el.tag.split("}")[-1] if "}" in el.tag else el.tag
+        if tag == "t":
+            t = el.text or ""
             parts.append(html.escape(t))
-        elif tag == 'sSub':
-            base = el.find('m:e', ns)
-            sub = el.find('m:sub', ns)
+        elif tag == "sSub":
+            base = el.find("m:e", ns)
+            sub = el.find("m:sub", ns)
             if base is not None:
                 process(base)
             if sub is not None:
                 sub_t = omath_to_unicode_inner(sub)
-                parts.append(f'<sub>{html.escape(sub_t)}</sub>')
-        elif tag == 'sSup':
-            base = el.find('m:e', ns)
-            sup = el.find('m:sup', ns)
+                parts.append(f"<sub>{html.escape(sub_t)}</sub>")
+        elif tag == "sSup":
+            base = el.find("m:e", ns)
+            sup = el.find("m:sup", ns)
             if base is not None:
                 process(base)
             if sup is not None:
                 sup_t = omath_to_unicode_inner(sup)
-                parts.append(f'<sup>{html.escape(sup_t)}</sup>')
-        elif tag == 'sSubSup':
-            base = el.find('m:e', ns)
-            sub = el.find('m:sub', ns)
-            sup = el.find('m:sup', ns)
+                parts.append(f"<sup>{html.escape(sup_t)}</sup>")
+        elif tag == "sSubSup":
+            base = el.find("m:e", ns)
+            sub = el.find("m:sub", ns)
+            sup = el.find("m:sup", ns)
             if base is not None:
                 process(base)
             if sub is not None:
                 sub_t = omath_to_unicode_inner(sub)
-                parts.append(f'<sub>{html.escape(sub_t)}</sub>')
+                parts.append(f"<sub>{html.escape(sub_t)}</sub>")
             if sup is not None:
                 sup_t = omath_to_unicode_inner(sup)
-                parts.append(f'<sup>{html.escape(sup_t)}</sup>')
-        elif tag == 'f':
-            num = el.find('m:num', ns)
-            den = el.find('m:den', ns)
-            num_t = omath_to_unicode_inner(num) if num is not None else ''
-            den_t = omath_to_unicode_inner(den) if den is not None else ''
-            parts.append(f'({html.escape(num_t)})/({html.escape(den_t)})')
-        elif tag == 'rad':
-            base = el.find('m:e', ns)
-            parts.append('\u221a(')
+                parts.append(f"<sup>{html.escape(sup_t)}</sup>")
+        elif tag == "f":
+            num = el.find("m:num", ns)
+            den = el.find("m:den", ns)
+            num_t = omath_to_unicode_inner(num) if num is not None else ""
+            den_t = omath_to_unicode_inner(den) if den is not None else ""
+            parts.append(f"({html.escape(num_t)})/({html.escape(den_t)})")
+        elif tag == "rad":
+            base = el.find("m:e", ns)
+            parts.append("\u221a(")
             if base is not None:
                 process(base)
-            parts.append(')')
-        elif tag == 'nary':
-            chr_el = el.find('m:naryPr/m:chr', ns)
-            op = chr_el.get(f'{{{mns}}}val', '\u2211') if chr_el is not None else '\u2211'
-            sub = el.find('m:sub', ns)
-            sup = el.find('m:sup', ns)
-            base = el.find('m:e', ns)
+            parts.append(")")
+        elif tag == "nary":
+            chr_el = el.find("m:naryPr/m:chr", ns)
+            op = (
+                chr_el.get(f"{{{mns}}}val", "\u2211")
+                if chr_el is not None
+                else "\u2211"
+            )
+            sub = el.find("m:sub", ns)
+            sup = el.find("m:sup", ns)
+            base = el.find("m:e", ns)
             parts.append(op)
             if sub is not None:
                 st = omath_to_unicode_inner(sub)
                 if st.strip():
-                    parts.append(f'<sub>{html.escape(st)}</sub>')
+                    parts.append(f"<sub>{html.escape(st)}</sub>")
             if sup is not None:
                 st = omath_to_unicode_inner(sup)
                 if st.strip():
-                    parts.append(f'<sup>{html.escape(st)}</sup>')
-            parts.append(' ')
+                    parts.append(f"<sup>{html.escape(st)}</sup>")
+            parts.append(" ")
             if base is not None:
                 process(base)
-        elif tag == 'd':
-            dPr = el.find('m:dPr', ns)
-            beg, end = '(', ')'
+        elif tag == "d":
+            dPr = el.find("m:dPr", ns)
+            beg, end = "(", ")"
             if dPr is not None:
-                b = dPr.find('m:begChr', ns)
-                e = dPr.find('m:endChr', ns)
+                b = dPr.find("m:begChr", ns)
+                e = dPr.find("m:endChr", ns)
                 if b is not None:
-                    beg = b.get(f'{{{mns}}}val', '(')
+                    beg = b.get(f"{{{mns}}}val", "(")
                 if e is not None:
-                    end = e.get(f'{{{mns}}}val', ')')
+                    end = e.get(f"{{{mns}}}val", ")")
             parts.append(html.escape(beg))
-            e_els = el.findall('m:e', ns)
+            e_els = el.findall("m:e", ns)
             for idx, ee in enumerate(e_els):
                 if idx > 0:
-                    parts.append(', ')
+                    parts.append(", ")
                 process(ee)
             parts.append(html.escape(end))
-        elif tag == 'acc':
-            base = el.find('m:e', ns)
+        elif tag == "acc":
+            base = el.find("m:e", ns)
             if base is not None:
                 process(base)
-        elif tag == 'bar':
-            base = el.find('m:e', ns)
+        elif tag == "bar":
+            base = el.find("m:e", ns)
             if base is not None:
                 process(base)
-        elif tag in ('r', 'e', 'sub', 'sup', 'num', 'den', 'deg',
-                     'oMath', 'oMathPara'):
+        elif tag in ("r", "e", "sub", "sup", "num", "den", "deg", "oMath", "oMathPara"):
             for child in el:
                 process(child)
-        elif tag.endswith('Pr'):
+        elif tag.endswith("Pr"):
             pass
         else:
             for child in el:
                 process(child)
 
     process(elem)
-    return ''.join(parts).strip()
+    return "".join(parts).strip()
 
 
 def normalize_text(text):
     """Normalize text for fuzzy matching."""
-    t = re.sub(r'\s+', ' ', text).strip()
-    t = t.replace('\u2013', '-').replace('\u2014', '-')
-    t = t.replace('\u2019', "'").replace('\u2018', "'")
-    t = t.replace('\u201c', '"').replace('\u201d', '"')
-    t = t.replace('\xa0', ' ')
+    t = re.sub(r"\s+", " ", text).strip()
+    t = t.replace("\u2013", "-").replace("\u2014", "-")
+    t = t.replace("\u2019", "'").replace("\u2018", "'")
+    t = t.replace("\u201c", '"').replace("\u201d", '"')
+    t = t.replace("\xa0", " ")
     return t
 
 
@@ -168,7 +179,7 @@ def extract_docx_math():
     result = []  # list of (plain_text, [math_html_strings])
 
     for p in doc.paragraphs:
-        omath_elems = p._element.findall('.//m:oMath', ns)
+        omath_elems = p._element.findall(".//m:oMath", ns)
         if not omath_elems:
             continue
 
@@ -208,7 +219,9 @@ def find_best_match(html_text, docx_paragraphs):
         score = len(common) / max(len(h_words), len(p_words))
 
         # Boost score for matching definition/proposition numbers
-        def_match = re.search(r'(Definition|Proposition|Theorem|Lemma)\s+\d+\.\d+', html_norm)
+        def_match = re.search(
+            r"(Definition|Proposition|Theorem|Lemma)\s+\d+\.\d+", html_norm
+        )
         if def_match and def_match.group() in plain:
             score += 0.5
 
@@ -224,17 +237,17 @@ def find_best_match(html_text, docx_paragraphs):
 def fix_html_line(line, docx_paragraphs):
     """Fix a single HTML line by inserting missing math."""
     # Check if this line has the empty-math pattern
-    if '</em>' not in line or '<em>' not in line:
+    if "</em>" not in line or "<em>" not in line:
         return line, 0
 
     # Count the gaps (</em>  <em> with no content between)
-    gaps = list(re.finditer(r'</em>\s*<em(?:\s[^>]*)?>|</em>\s*<em>', line))
+    gaps = list(re.finditer(r"</em>\s*<em(?:\s[^>]*)?>|</em>\s*<em>", line))
     if not gaps:
         return line, 0
 
     # Extract the text content (strip HTML tags) for matching
-    text_only = re.sub(r'<[^>]+>', '', line)
-    text_only = re.sub(r'\s+', ' ', text_only).strip()
+    text_only = re.sub(r"<[^>]+>", "", line)
+    text_only = re.sub(r"\s+", " ", text_only).strip()
 
     match = find_best_match(text_only, docx_paragraphs)
     if not match:
@@ -253,7 +266,7 @@ def fix_html_line(line, docx_paragraphs):
         if math_idx >= len(math_list):
             break
         # Add everything before this gap
-        new_parts.append(result[pos:gap.start()])
+        new_parts.append(result[pos : gap.start()])
         # Insert the math
         math_html = math_list[math_idx]
         new_parts.append(f'</em> <em class="math">{math_html}</em> <em>')
@@ -262,7 +275,7 @@ def fix_html_line(line, docx_paragraphs):
 
     # Add remaining
     new_parts.append(result[pos:])
-    fixed = ''.join(new_parts)
+    fixed = "".join(new_parts)
 
     fixes = min(len(gaps), len(math_list))
     return fixed, fixes
@@ -270,7 +283,7 @@ def fix_html_line(line, docx_paragraphs):
 
 def process_file(filepath, docx_paragraphs):
     """Process a single HTML file."""
-    with open(filepath, 'r', encoding='utf-8') as f:
+    with open(filepath, "r", encoding="utf-8") as f:
         lines = f.readlines()
 
     total_fixes = 0
@@ -282,7 +295,7 @@ def process_file(filepath, docx_paragraphs):
         total_fixes += fixes
 
     if total_fixes > 0:
-        with open(filepath, 'w', encoding='utf-8') as f:
+        with open(filepath, "w", encoding="utf-8") as f:
             f.writelines(new_lines)
 
     return total_fixes
@@ -294,19 +307,19 @@ def main():
     print(f"  Found {len(docx_paragraphs)} paragraphs with math\n")
 
     # Also add a CSS rule for math styling
-    css_path = os.path.join(BOOK_DIR, 'book.css')
-    with open(css_path, 'r', encoding='utf-8') as f:
+    css_path = os.path.join(BOOK_DIR, "book.css")
+    with open(css_path, "r", encoding="utf-8") as f:
         css = f.read()
-    if '.math' not in css:
+    if ".math" not in css:
         css += '\n\n/* Restored math variables */\nem.math { font-style: italic; font-family: "Cambria Math", "STIX Two Math", serif; }\n'
-        with open(css_path, 'w', encoding='utf-8') as f:
+        with open(css_path, "w", encoding="utf-8") as f:
             f.write(css)
         print("Added .math CSS rule to book.css")
 
     # Process all HTML files
     total_all = 0
     for fname in sorted(os.listdir(BOOK_DIR)):
-        if not fname.endswith('.html'):
+        if not fname.endswith(".html"):
             continue
         filepath = os.path.join(BOOK_DIR, fname)
         fixes = process_file(filepath, docx_paragraphs)
@@ -317,5 +330,5 @@ def main():
     print(f"\nTotal: {total_all} math expressions restored across all files")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/fix_math2.py
+++ b/fix_math2.py
@@ -8,119 +8,164 @@ find the matching docx paragraph, extract m:oMath elements in order,
 and replace each double-space gap with the corresponding math HTML.
 """
 
-import sys, io, re, os, html as html_mod
-sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+import html as html_mod
+import io
+import os
+import re
+import sys
 
-from docx import Document
-import lxml.etree as ET
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
 
-BOOK_DIR = r'C:\source\erisml-lib\docs\book'
-DOCX_PATH = r'C:\source\erisml-lib\docs\papers\foundations\Geometric Ethics - The Mathematical Structure of Moral Reasoning - Bond - v1.14 - Mar 2026.docx'
+from docx import Document  # noqa: E402
 
-ns = {'m': 'http://schemas.openxmlformats.org/officeDocument/2006/math',
-      'w': 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'}
+BOOK_DIR = r"C:\source\erisml-lib\docs\book"
+DOCX_PATH = r"C:\source\erisml-lib\docs\papers\foundations\Geometric Ethics - The Mathematical Structure of Moral Reasoning - Bond - v1.14 - Mar 2026.docx"
+
+ns = {
+    "m": "http://schemas.openxmlformats.org/officeDocument/2006/math",
+    "w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+}
 
 
 def omath_to_unicode_inner(elem):
     parts = []
+
     def process(el):
-        tag = el.tag.split('}')[-1] if '}' in el.tag else el.tag
-        if tag == 't':
-            parts.append(el.text or '')
-        elif tag in ('r', 'e', 'sub', 'sup', 'num', 'den', 'deg'):
-            for child in el: process(child)
-        elif tag.endswith('Pr'):
+        tag = el.tag.split("}")[-1] if "}" in el.tag else el.tag
+        if tag == "t":
+            parts.append(el.text or "")
+        elif tag in ("r", "e", "sub", "sup", "num", "den", "deg"):
+            for child in el:
+                process(child)
+        elif tag.endswith("Pr"):
             pass
         else:
-            for child in el: process(child)
+            for child in el:
+                process(child)
+
     process(elem)
-    return ''.join(parts).strip()
+    return "".join(parts).strip()
 
 
 def omath_to_html(elem):
     """Convert Office MathML to inline HTML."""
     parts = []
-    mns = 'http://schemas.openxmlformats.org/officeDocument/2006/math'
+    mns = "http://schemas.openxmlformats.org/officeDocument/2006/math"
 
     def process(el):
-        tag = el.tag.split('}')[-1] if '}' in el.tag else el.tag
-        if tag == 't':
-            parts.append(html_mod.escape(el.text or ''))
-        elif tag == 'sSub':
-            base = el.find('m:e', ns); sub = el.find('m:sub', ns)
-            if base is not None: process(base)
+        tag = el.tag.split("}")[-1] if "}" in el.tag else el.tag
+        if tag == "t":
+            parts.append(html_mod.escape(el.text or ""))
+        elif tag == "sSub":
+            base = el.find("m:e", ns)
+            sub = el.find("m:sub", ns)
+            if base is not None:
+                process(base)
             if sub is not None:
-                parts.append(f'<sub>{html_mod.escape(omath_to_unicode_inner(sub))}</sub>')
-        elif tag == 'sSup':
-            base = el.find('m:e', ns); sup = el.find('m:sup', ns)
-            if base is not None: process(base)
+                parts.append(
+                    f"<sub>{html_mod.escape(omath_to_unicode_inner(sub))}</sub>"
+                )
+        elif tag == "sSup":
+            base = el.find("m:e", ns)
+            sup = el.find("m:sup", ns)
+            if base is not None:
+                process(base)
             if sup is not None:
-                parts.append(f'<sup>{html_mod.escape(omath_to_unicode_inner(sup))}</sup>')
-        elif tag == 'sSubSup':
-            base = el.find('m:e', ns); sub = el.find('m:sub', ns); sup = el.find('m:sup', ns)
-            if base is not None: process(base)
+                parts.append(
+                    f"<sup>{html_mod.escape(omath_to_unicode_inner(sup))}</sup>"
+                )
+        elif tag == "sSubSup":
+            base = el.find("m:e", ns)
+            sub = el.find("m:sub", ns)
+            sup = el.find("m:sup", ns)
+            if base is not None:
+                process(base)
             if sub is not None:
-                parts.append(f'<sub>{html_mod.escape(omath_to_unicode_inner(sub))}</sub>')
+                parts.append(
+                    f"<sub>{html_mod.escape(omath_to_unicode_inner(sub))}</sub>"
+                )
             if sup is not None:
-                parts.append(f'<sup>{html_mod.escape(omath_to_unicode_inner(sup))}</sup>')
-        elif tag == 'f':
-            num = el.find('m:num', ns); den = el.find('m:den', ns)
-            n = html_mod.escape(omath_to_unicode_inner(num)) if num is not None else ''
-            d = html_mod.escape(omath_to_unicode_inner(den)) if den is not None else ''
-            parts.append(f'({n})/({d})')
-        elif tag == 'rad':
-            base = el.find('m:e', ns)
-            parts.append('\u221a(')
-            if base is not None: process(base)
-            parts.append(')')
-        elif tag == 'nary':
-            chr_el = el.find('m:naryPr/m:chr', ns)
-            op = chr_el.get(f'{{{mns}}}val', '\u2211') if chr_el is not None else '\u2211'
-            sub = el.find('m:sub', ns); sup = el.find('m:sup', ns); base = el.find('m:e', ns)
+                parts.append(
+                    f"<sup>{html_mod.escape(omath_to_unicode_inner(sup))}</sup>"
+                )
+        elif tag == "f":
+            num = el.find("m:num", ns)
+            den = el.find("m:den", ns)
+            n = html_mod.escape(omath_to_unicode_inner(num)) if num is not None else ""
+            d = html_mod.escape(omath_to_unicode_inner(den)) if den is not None else ""
+            parts.append(f"({n})/({d})")
+        elif tag == "rad":
+            base = el.find("m:e", ns)
+            parts.append("\u221a(")
+            if base is not None:
+                process(base)
+            parts.append(")")
+        elif tag == "nary":
+            chr_el = el.find("m:naryPr/m:chr", ns)
+            op = (
+                chr_el.get(f"{{{mns}}}val", "\u2211")
+                if chr_el is not None
+                else "\u2211"
+            )
+            sub = el.find("m:sub", ns)
+            sup = el.find("m:sup", ns)
+            base = el.find("m:e", ns)
             parts.append(op)
             if sub is not None:
                 st = omath_to_unicode_inner(sub)
-                if st.strip(): parts.append(f'<sub>{html_mod.escape(st)}</sub>')
+                if st.strip():
+                    parts.append(f"<sub>{html_mod.escape(st)}</sub>")
             if sup is not None:
                 st = omath_to_unicode_inner(sup)
-                if st.strip(): parts.append(f'<sup>{html_mod.escape(st)}</sup>')
-            parts.append(' ')
-            if base is not None: process(base)
-        elif tag == 'd':
-            dPr = el.find('m:dPr', ns); beg, end = '(', ')'
+                if st.strip():
+                    parts.append(f"<sup>{html_mod.escape(st)}</sup>")
+            parts.append(" ")
+            if base is not None:
+                process(base)
+        elif tag == "d":
+            dPr = el.find("m:dPr", ns)
+            beg, end = "(", ")"
             if dPr is not None:
-                b = dPr.find('m:begChr', ns); e = dPr.find('m:endChr', ns)
-                if b is not None: beg = b.get(f'{{{mns}}}val', '(')
-                if e is not None: end = e.get(f'{{{mns}}}val', ')')
+                b = dPr.find("m:begChr", ns)
+                e = dPr.find("m:endChr", ns)
+                if b is not None:
+                    beg = b.get(f"{{{mns}}}val", "(")
+                if e is not None:
+                    end = e.get(f"{{{mns}}}val", ")")
             parts.append(html_mod.escape(beg))
-            e_els = el.findall('m:e', ns)
+            e_els = el.findall("m:e", ns)
             for idx, ee in enumerate(e_els):
-                if idx > 0: parts.append(', ')
+                if idx > 0:
+                    parts.append(", ")
                 process(ee)
             parts.append(html_mod.escape(end))
-        elif tag == 'acc':
-            base = el.find('m:e', ns)
-            if base is not None: process(base)
-        elif tag == 'bar':
-            base = el.find('m:e', ns)
-            if base is not None: process(base)
-        elif tag in ('r', 'e', 'sub', 'sup', 'num', 'den', 'deg', 'oMath', 'oMathPara'):
-            for child in el: process(child)
-        elif tag.endswith('Pr'):
+        elif tag == "acc":
+            base = el.find("m:e", ns)
+            if base is not None:
+                process(base)
+        elif tag == "bar":
+            base = el.find("m:e", ns)
+            if base is not None:
+                process(base)
+        elif tag in ("r", "e", "sub", "sup", "num", "den", "deg", "oMath", "oMathPara"):
+            for child in el:
+                process(child)
+        elif tag.endswith("Pr"):
             pass
         else:
-            for child in el: process(child)
+            for child in el:
+                process(child)
 
     process(elem)
-    return ''.join(parts).strip()
+    return "".join(parts).strip()
 
 
 def normalize(text):
-    t = re.sub(r'\s+', ' ', text).strip()
-    t = t.replace('\u2013', '-').replace('\u2014', '-')
-    t = t.replace('\u2019', "'").replace('\u2018', "'")
-    t = t.replace('\u201c', '"').replace('\u201d', '"')
-    t = t.replace('\xa0', ' ')
+    t = re.sub(r"\s+", " ", text).strip()
+    t = t.replace("\u2013", "-").replace("\u2014", "-")
+    t = t.replace("\u2019", "'").replace("\u2018", "'")
+    t = t.replace("\u201c", '"').replace("\u201d", '"')
+    t = t.replace("\xa0", " ")
     return t.lower()
 
 
@@ -129,21 +174,21 @@ def get_text_fragments(para_element):
     type is 'text' for regular runs, 'math' for m:oMath elements."""
     fragments = []
     for child in para_element:
-        tag = child.tag.split('}')[-1] if '}' in child.tag else child.tag
-        if tag == 'r':
-            t_el = child.find('w:t', ns)
+        tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+        if tag == "r":
+            t_el = child.find("w:t", ns)
             if t_el is not None and t_el.text:
-                fragments.append(('text', t_el.text))
-        elif tag == 'oMath':
+                fragments.append(("text", t_el.text))
+        elif tag == "oMath":
             math_html = omath_to_html(child)
             if math_html:
-                fragments.append(('math', math_html))
-        elif tag == 'hyperlink':
+                fragments.append(("math", math_html))
+        elif tag == "hyperlink":
             # Extract text from hyperlink runs
-            for r in child.findall('w:r', ns):
-                t_el = r.find('w:t', ns)
+            for r in child.findall("w:r", ns):
+                t_el = r.find("w:t", ns)
                 if t_el is not None and t_el.text:
-                    fragments.append(('text', t_el.text))
+                    fragments.append(("text", t_el.text))
     return fragments
 
 
@@ -151,7 +196,7 @@ def build_docx_index(doc):
     """Build an index of docx paragraphs with math, keyed by text fingerprint."""
     index = {}
     for p in doc.paragraphs:
-        omath_elems = p._element.findall('.//m:oMath', ns)
+        omath_elems = p._element.findall(".//m:oMath", ns)
         if not omath_elems:
             continue
 
@@ -160,7 +205,7 @@ def build_docx_index(doc):
             continue
 
         fragments = get_text_fragments(p._element)
-        math_list = [f[1] for f in fragments if f[0] == 'math']
+        math_list = [f[1] for f in fragments if f[0] == "math"]
 
         if not math_list:
             continue
@@ -200,7 +245,7 @@ def find_match(html_text, docx_index):
         score = len(common) / max(len(h_words), len(p_words))
 
         # Boost for definition/proposition matches
-        def_m = re.search(r'(definition|proposition|theorem|lemma)\s+\d+\.\d+', h)
+        def_m = re.search(r"(definition|proposition|theorem|lemma)\s+\d+\.\d+", h)
         if def_m and def_m.group() in plain:
             score += 0.5
 
@@ -218,7 +263,7 @@ def rebuild_paragraph(html_line, fragments):
     into the double-space gaps in the HTML."""
 
     # Extract the tag wrapper
-    tag_match = re.match(r'(<p[^>]*>)(.*?)(</p>)', html_line, re.DOTALL)
+    tag_match = re.match(r"(<p[^>]*>)(.*?)(</p>)", html_line, re.DOTALL)
     if not tag_match:
         return html_line, 0
 
@@ -227,7 +272,7 @@ def rebuild_paragraph(html_line, fragments):
     close_tag = tag_match.group(3)
 
     # Get the math elements in order
-    math_items = [f[1] for f in fragments if f[0] == 'math']
+    math_items = [f[1] for f in fragments if f[0] == "math"]
     if not math_items:
         return html_line, 0
 
@@ -243,19 +288,19 @@ def rebuild_paragraph(html_line, fragments):
     fixes = 0
 
     while i < len(inner):
-        if inner[i] == '<':
+        if inner[i] == "<":
             # Skip HTML tag
-            end = inner.find('>', i)
+            end = inner.find(">", i)
             if end == -1:
                 result.append(inner[i:])
                 break
-            result.append(inner[i:end + 1])
+            result.append(inner[i : end + 1])
             i = end + 1
-        elif inner[i] == ' ' and i + 1 < len(inner) and inner[i + 1] == ' ':
+        elif inner[i] == " " and i + 1 < len(inner) and inner[i + 1] == " ":
             # Double space found - this is likely a missing math variable
             # Consume all spaces
             j = i
-            while j < len(inner) and inner[j] == ' ':
+            while j < len(inner) and inner[j] == " ":
                 j += 1
 
             if math_idx < len(math_items):
@@ -271,32 +316,32 @@ def rebuild_paragraph(html_line, fragments):
             result.append(inner[i])
             i += 1
 
-    rebuilt = open_tag + ''.join(result) + close_tag
+    rebuilt = open_tag + "".join(result) + close_tag
     return rebuilt, fixes
 
 
 def process_file(filepath, docx_index):
     """Process a single HTML file."""
-    with open(filepath, 'r', encoding='utf-8') as f:
+    with open(filepath, "r", encoding="utf-8") as f:
         content = f.read()
 
-    lines = content.split('\n')
+    lines = content.split("\n")
     total_fixes = 0
     new_lines = []
 
     for line in lines:
         # Check if this line is a paragraph with double-spaces
-        if '<p ' not in line or '  ' not in line:
+        if "<p " not in line or "  " not in line:
             new_lines.append(line)
             continue
 
         # Strip tags to get text
-        text_only = re.sub(r'<[^>]+>', '', line)
+        text_only = re.sub(r"<[^>]+>", "", line)
 
         # Check for double-spaces indicating missing math
-        if not re.search(r'(?<=[a-zA-Z)}\]]) {2}(?=[a-zA-Z(,.\[{])', text_only):
+        if not re.search(r"(?<=[a-zA-Z)}\]]) {2}(?=[a-zA-Z(,.\[{])", text_only):
             # Also check for patterns like "If , " or "across . "
-            if not re.search(r' {2}', text_only):
+            if not re.search(r" {2}", text_only):
                 new_lines.append(line)
                 continue
 
@@ -314,8 +359,8 @@ def process_file(filepath, docx_index):
         total_fixes += fixes
 
     if total_fixes > 0:
-        with open(filepath, 'w', encoding='utf-8', newline='\n') as f:
-            f.write('\n'.join(new_lines))
+        with open(filepath, "w", encoding="utf-8", newline="\n") as f:
+            f.write("\n".join(new_lines))
 
     return total_fixes
 
@@ -329,7 +374,7 @@ def main():
 
     total_all = 0
     for fname in sorted(os.listdir(BOOK_DIR)):
-        if not fname.endswith('.html'):
+        if not fname.endswith(".html"):
             continue
         filepath = os.path.join(BOOK_DIR, fname)
         fixes = process_file(filepath, docx_index)
@@ -340,5 +385,5 @@ def main():
     print(f"\nTotal: {total_all} math expressions restored")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/fix_math3.py
+++ b/fix_math3.py
@@ -8,127 +8,186 @@ the full text by interleaving text and math from the docx, then replace
 the entire paragraph content.
 """
 
-import sys, io, re, os, html as html_mod
-sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+import html as html_mod
+import io
+import os
+import re
+import sys
 
-from docx import Document
-import lxml.etree as ET
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
 
-BOOK_DIR = r'C:\source\erisml-lib\docs\book'
-DOCX_PATH = r'C:\source\erisml-lib\docs\papers\foundations\Geometric Ethics - The Mathematical Structure of Moral Reasoning - Bond - v1.14 - Mar 2026.docx'
+from docx import Document  # noqa: E402
 
-ns = {'m': 'http://schemas.openxmlformats.org/officeDocument/2006/math',
-      'w': 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'}
+BOOK_DIR = r"C:\source\erisml-lib\docs\book"
+DOCX_PATH = r"C:\source\erisml-lib\docs\papers\foundations\Geometric Ethics - The Mathematical Structure of Moral Reasoning - Bond - v1.14 - Mar 2026.docx"
+
+ns = {
+    "m": "http://schemas.openxmlformats.org/officeDocument/2006/math",
+    "w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+}
 
 
 def omath_to_unicode_inner(elem):
     parts = []
+
     def process(el):
-        tag = el.tag.split('}')[-1] if '}' in el.tag else el.tag
-        if tag == 't': parts.append(el.text or '')
-        elif tag in ('r', 'e', 'sub', 'sup', 'num', 'den', 'deg'):
-            for child in el: process(child)
-        elif tag.endswith('Pr'): pass
+        tag = el.tag.split("}")[-1] if "}" in el.tag else el.tag
+        if tag == "t":
+            parts.append(el.text or "")
+        elif tag in ("r", "e", "sub", "sup", "num", "den", "deg"):
+            for child in el:
+                process(child)
+        elif tag.endswith("Pr"):
+            pass
         else:
-            for child in el: process(child)
+            for child in el:
+                process(child)
+
     process(elem)
-    return ''.join(parts).strip()
+    return "".join(parts).strip()
 
 
 def omath_to_html(elem):
     parts = []
-    mns = 'http://schemas.openxmlformats.org/officeDocument/2006/math'
+    mns = "http://schemas.openxmlformats.org/officeDocument/2006/math"
+
     def process(el):
-        tag = el.tag.split('}')[-1] if '}' in el.tag else el.tag
-        if tag == 't': parts.append(html_mod.escape(el.text or ''))
-        elif tag == 'sSub':
-            base = el.find('m:e', ns); sub = el.find('m:sub', ns)
-            if base is not None: process(base)
+        tag = el.tag.split("}")[-1] if "}" in el.tag else el.tag
+        if tag == "t":
+            parts.append(html_mod.escape(el.text or ""))
+        elif tag == "sSub":
+            base = el.find("m:e", ns)
+            sub = el.find("m:sub", ns)
+            if base is not None:
+                process(base)
             if sub is not None:
-                parts.append(f'<sub>{html_mod.escape(omath_to_unicode_inner(sub))}</sub>')
-        elif tag == 'sSup':
-            base = el.find('m:e', ns); sup = el.find('m:sup', ns)
-            if base is not None: process(base)
+                parts.append(
+                    f"<sub>{html_mod.escape(omath_to_unicode_inner(sub))}</sub>"
+                )
+        elif tag == "sSup":
+            base = el.find("m:e", ns)
+            sup = el.find("m:sup", ns)
+            if base is not None:
+                process(base)
             if sup is not None:
-                parts.append(f'<sup>{html_mod.escape(omath_to_unicode_inner(sup))}</sup>')
-        elif tag == 'sSubSup':
-            base = el.find('m:e', ns); sub = el.find('m:sub', ns); sup = el.find('m:sup', ns)
-            if base is not None: process(base)
+                parts.append(
+                    f"<sup>{html_mod.escape(omath_to_unicode_inner(sup))}</sup>"
+                )
+        elif tag == "sSubSup":
+            base = el.find("m:e", ns)
+            sub = el.find("m:sub", ns)
+            sup = el.find("m:sup", ns)
+            if base is not None:
+                process(base)
             if sub is not None:
-                parts.append(f'<sub>{html_mod.escape(omath_to_unicode_inner(sub))}</sub>')
+                parts.append(
+                    f"<sub>{html_mod.escape(omath_to_unicode_inner(sub))}</sub>"
+                )
             if sup is not None:
-                parts.append(f'<sup>{html_mod.escape(omath_to_unicode_inner(sup))}</sup>')
-        elif tag == 'f':
-            num = el.find('m:num', ns); den = el.find('m:den', ns)
-            n = html_mod.escape(omath_to_unicode_inner(num)) if num is not None else ''
-            d = html_mod.escape(omath_to_unicode_inner(den)) if den is not None else ''
-            parts.append(f'({n})/({d})')
-        elif tag == 'rad':
-            base = el.find('m:e', ns)
-            parts.append('\u221a(')
-            if base is not None: process(base)
-            parts.append(')')
-        elif tag == 'nary':
-            chr_el = el.find('m:naryPr/m:chr', ns)
-            op = chr_el.get(f'{{{mns}}}val', '\u2211') if chr_el is not None else '\u2211'
-            sub = el.find('m:sub', ns); sup = el.find('m:sup', ns); base = el.find('m:e', ns)
+                parts.append(
+                    f"<sup>{html_mod.escape(omath_to_unicode_inner(sup))}</sup>"
+                )
+        elif tag == "f":
+            num = el.find("m:num", ns)
+            den = el.find("m:den", ns)
+            n = html_mod.escape(omath_to_unicode_inner(num)) if num is not None else ""
+            d = html_mod.escape(omath_to_unicode_inner(den)) if den is not None else ""
+            parts.append(f"({n})/({d})")
+        elif tag == "rad":
+            base = el.find("m:e", ns)
+            parts.append("\u221a(")
+            if base is not None:
+                process(base)
+            parts.append(")")
+        elif tag == "nary":
+            chr_el = el.find("m:naryPr/m:chr", ns)
+            op = (
+                chr_el.get(f"{{{mns}}}val", "\u2211")
+                if chr_el is not None
+                else "\u2211"
+            )
+            sub = el.find("m:sub", ns)
+            sup = el.find("m:sup", ns)
+            base = el.find("m:e", ns)
             parts.append(op)
             if sub is not None:
                 st = omath_to_unicode_inner(sub)
-                if st.strip(): parts.append(f'<sub>{html_mod.escape(st)}</sub>')
+                if st.strip():
+                    parts.append(f"<sub>{html_mod.escape(st)}</sub>")
             if sup is not None:
                 st = omath_to_unicode_inner(sup)
-                if st.strip(): parts.append(f'<sup>{html_mod.escape(st)}</sup>')
-            parts.append(' ')
-            if base is not None: process(base)
-        elif tag == 'd':
-            dPr = el.find('m:dPr', ns); beg, end = '(', ')'
+                if st.strip():
+                    parts.append(f"<sup>{html_mod.escape(st)}</sup>")
+            parts.append(" ")
+            if base is not None:
+                process(base)
+        elif tag == "d":
+            dPr = el.find("m:dPr", ns)
+            beg, end = "(", ")"
             if dPr is not None:
-                b = dPr.find('m:begChr', ns); e = dPr.find('m:endChr', ns)
-                if b is not None: beg = b.get(f'{{{mns}}}val', '(')
-                if e is not None: end = e.get(f'{{{mns}}}val', ')')
+                b = dPr.find("m:begChr", ns)
+                e = dPr.find("m:endChr", ns)
+                if b is not None:
+                    beg = b.get(f"{{{mns}}}val", "(")
+                if e is not None:
+                    end = e.get(f"{{{mns}}}val", ")")
             parts.append(html_mod.escape(beg))
-            e_els = el.findall('m:e', ns)
+            e_els = el.findall("m:e", ns)
             for idx, ee in enumerate(e_els):
-                if idx > 0: parts.append(', ')
+                if idx > 0:
+                    parts.append(", ")
                 process(ee)
             parts.append(html_mod.escape(end))
-        elif tag == 'acc':
-            base = el.find('m:e', ns)
-            if base is not None: process(base)
-        elif tag == 'bar':
-            base = el.find('m:e', ns)
-            if base is not None: process(base)
-        elif tag in ('r', 'e', 'sub', 'sup', 'num', 'den', 'deg', 'oMath', 'oMathPara'):
-            for child in el: process(child)
-        elif tag.endswith('Pr'): pass
+        elif tag == "acc":
+            base = el.find("m:e", ns)
+            if base is not None:
+                process(base)
+        elif tag == "bar":
+            base = el.find("m:e", ns)
+            if base is not None:
+                process(base)
+        elif tag in ("r", "e", "sub", "sup", "num", "den", "deg", "oMath", "oMathPara"):
+            for child in el:
+                process(child)
+        elif tag.endswith("Pr"):
+            pass
         else:
-            for child in el: process(child)
+            for child in el:
+                process(child)
+
     process(elem)
-    return ''.join(parts).strip()
+    return "".join(parts).strip()
 
 
 def get_fragments(para_element):
     """Get ordered list of (type, text, formatting) from a docx paragraph."""
     fragments = []
     for child in para_element:
-        tag = child.tag.split('}')[-1] if '}' in child.tag else child.tag
-        if tag == 'r':
-            rPr = child.find('w:rPr', ns)
-            is_bold = rPr is not None and rPr.find('w:b', ns) is not None if rPr is not None else False
-            is_italic = rPr is not None and rPr.find('w:i', ns) is not None if rPr is not None else False
-            t_el = child.find('w:t', ns)
+        tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+        if tag == "r":
+            rPr = child.find("w:rPr", ns)
+            is_bold = (
+                rPr is not None and rPr.find("w:b", ns) is not None
+                if rPr is not None
+                else False
+            )
+            is_italic = (
+                rPr is not None and rPr.find("w:i", ns) is not None
+                if rPr is not None
+                else False
+            )
+            t_el = child.find("w:t", ns)
             if t_el is not None and t_el.text:
-                fragments.append(('text', t_el.text, is_bold, is_italic))
-        elif tag == 'oMath':
+                fragments.append(("text", t_el.text, is_bold, is_italic))
+        elif tag == "oMath":
             math_html = omath_to_html(child)
             if math_html:
-                fragments.append(('math', math_html, False, True))
-        elif tag == 'hyperlink':
-            for r in child.findall('w:r', ns):
-                t_el = r.find('w:t', ns)
+                fragments.append(("math", math_html, False, True))
+        elif tag == "hyperlink":
+            for r in child.findall("w:r", ns):
+                t_el = r.find("w:t", ns)
                 if t_el is not None and t_el.text:
-                    fragments.append(('text', t_el.text, False, False))
+                    fragments.append(("text", t_el.text, False, False))
     return fragments
 
 
@@ -143,51 +202,51 @@ def rebuild_from_fragments(fragments):
         is_bold = frag[2] if len(frag) > 2 else False
         is_italic = frag[3] if len(frag) > 3 else False
 
-        if ftype == 'math':
+        if ftype == "math":
             # Close any open tags
             if in_italic:
-                parts.append('</em>')
+                parts.append("</em>")
                 in_italic = False
             if in_bold:
-                parts.append('</strong>')
+                parts.append("</strong>")
                 in_bold = False
             parts.append(f'<em class="math">{text}</em>')
         else:
             # Handle bold/italic transitions
             if is_bold and not in_bold:
                 if in_italic:
-                    parts.append('</em>')
+                    parts.append("</em>")
                     in_italic = False
-                parts.append('<strong>')
+                parts.append("<strong>")
                 in_bold = True
             elif not is_bold and in_bold:
-                parts.append('</strong>')
+                parts.append("</strong>")
                 in_bold = False
 
             if is_italic and not in_italic:
-                parts.append('<em>')
+                parts.append("<em>")
                 in_italic = True
             elif not is_italic and in_italic:
-                parts.append('</em>')
+                parts.append("</em>")
                 in_italic = False
 
             parts.append(html_mod.escape(text))
 
     # Close any remaining tags
     if in_italic:
-        parts.append('</em>')
+        parts.append("</em>")
     if in_bold:
-        parts.append('</strong>')
+        parts.append("</strong>")
 
-    return ''.join(parts)
+    return "".join(parts)
 
 
 def normalize(text):
-    t = re.sub(r'\s+', ' ', text).strip()
-    t = t.replace('\u2013', '-').replace('\u2014', '-')
-    t = t.replace('\u2019', "'").replace('\u2018', "'")
-    t = t.replace('\u201c', '"').replace('\u201d', '"')
-    t = t.replace('\xa0', ' ')
+    t = re.sub(r"\s+", " ", text).strip()
+    t = t.replace("\u2013", "-").replace("\u2014", "-")
+    t = t.replace("\u2019", "'").replace("\u2018", "'")
+    t = t.replace("\u201c", '"').replace("\u201d", '"')
+    t = t.replace("\xa0", " ")
     return t.lower()
 
 
@@ -195,7 +254,7 @@ def build_docx_db(doc):
     """Build a database of all docx paragraphs with math."""
     db = []
     for p in doc.paragraphs:
-        omath_elems = p._element.findall('.//m:oMath', ns)
+        omath_elems = p._element.findall(".//m:oMath", ns)
         if not omath_elems:
             continue
         plain = normalize(p.text)
@@ -229,7 +288,7 @@ def find_match(html_text, db):
         score = len(common) / max(len(h_words), len(p_words))
 
         # Boost for definition/proposition matches
-        def_m = re.search(r'(definition|proposition|theorem|lemma)\s+\d+\.\d+', h)
+        def_m = re.search(r"(definition|proposition|theorem|lemma)\s+\d+\.\d+", h)
         if def_m and def_m.group() in plain:
             score += 0.5
 
@@ -245,42 +304,42 @@ def find_match(html_text, db):
 def has_missing_math(text_only):
     """Check if a text line has suspicious patterns indicating missing math."""
     # Double spaces
-    if '  ' in text_only:
+    if "  " in text_only:
         return True
     # "If ," "across ." "either  or" etc.
-    if re.search(r'\bIf [,.]', text_only):
+    if re.search(r"\bIf [,.]", text_only):
         return True
-    if re.search(r'across [,.]', text_only):
+    if re.search(r"across [,.]", text_only):
         return True
-    if re.search(r'(?:over|on|in|of|from|by|with) [,.]', text_only):
+    if re.search(r"(?:over|on|in|of|from|by|with) [,.]", text_only):
         return True
-    if re.search(r'\bthen [,.]', text_only):
+    if re.search(r"\bthen [,.]", text_only):
         return True
-    if re.search(r'\bwhere [,.]', text_only):
+    if re.search(r"\bwhere [,.]", text_only):
         return True
-    if re.search(r'\bthat [,.]', text_only):
+    if re.search(r"\bthat [,.]", text_only):
         return True
     # Standalone period/comma after space suggesting missing var
-    if re.search(r'[a-z] [,.;:] [A-Z]', text_only):
+    if re.search(r"[a-z] [,.;:] [A-Z]", text_only):
         return True
     return False
 
 
 def process_file(filepath, db):
     """Process a single HTML file."""
-    with open(filepath, 'r', encoding='utf-8') as f:
+    with open(filepath, "r", encoding="utf-8") as f:
         content = f.read()
 
-    lines = content.split('\n')
+    lines = content.split("\n")
     total_fixes = 0
     new_lines = []
 
     for line in lines:
-        if '<p ' not in line:
+        if "<p " not in line:
             new_lines.append(line)
             continue
 
-        text_only = re.sub(r'<[^>]+>', '', line)
+        text_only = re.sub(r"<[^>]+>", "", line)
 
         if not has_missing_math(text_only):
             new_lines.append(line)
@@ -299,14 +358,14 @@ def process_file(filepath, db):
         plain, fragments = match
 
         # Extract the opening tag and class
-        tag_match = re.match(r'(<p[^>]*>)', line)
+        tag_match = re.match(r"(<p[^>]*>)", line)
         if not tag_match:
             new_lines.append(line)
             continue
 
         open_tag = tag_match.group(1)
         rebuilt_content = rebuild_from_fragments(fragments)
-        new_line = f'{open_tag}{rebuilt_content}</p>'
+        new_line = f"{open_tag}{rebuilt_content}</p>"
 
         # Verify the rebuild has actual math
         if 'class="math"' in new_line:
@@ -316,8 +375,8 @@ def process_file(filepath, db):
             new_lines.append(line)
 
     if total_fixes > 0:
-        with open(filepath, 'w', encoding='utf-8', newline='\n') as f:
-            f.write('\n'.join(new_lines))
+        with open(filepath, "w", encoding="utf-8", newline="\n") as f:
+            f.write("\n".join(new_lines))
 
     return total_fixes
 
@@ -331,7 +390,7 @@ def main():
 
     total_all = 0
     for fname in sorted(os.listdir(BOOK_DIR)):
-        if not fname.endswith('.html'):
+        if not fname.endswith(".html"):
             continue
         filepath = os.path.join(BOOK_DIR, fname)
         fixes = process_file(filepath, db)
@@ -342,5 +401,5 @@ def main():
     print(f"\nTotal: {total_all} paragraphs rebuilt")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/fix_math4.py
+++ b/fix_math4.py
@@ -11,116 +11,168 @@ display-math paragraph, find the surrounding text paragraphs in
 both docx and HTML to locate where the equation should be inserted.
 """
 
-import sys, io, re, os, html as html_mod
-sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+import html as html_mod
+import io
+import os
+import re
+import sys
 
-from docx import Document
-import lxml.etree as ET
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
 
-BOOK_DIR = r'C:\source\erisml-lib\docs\book'
-DOCX_PATH = r'C:\source\erisml-lib\docs\papers\foundations\Geometric Ethics - The Mathematical Structure of Moral Reasoning - Bond - v1.14 - Mar 2026.docx'
+from docx import Document  # noqa: E402
 
-ns = {'m': 'http://schemas.openxmlformats.org/officeDocument/2006/math',
-      'w': 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'}
+BOOK_DIR = r"C:\source\erisml-lib\docs\book"
+DOCX_PATH = r"C:\source\erisml-lib\docs\papers\foundations\Geometric Ethics - The Mathematical Structure of Moral Reasoning - Bond - v1.14 - Mar 2026.docx"
+
+ns = {
+    "m": "http://schemas.openxmlformats.org/officeDocument/2006/math",
+    "w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+}
 
 
 def omath_to_unicode_inner(elem):
     parts = []
+
     def process(el):
-        tag = el.tag.split('}')[-1] if '}' in el.tag else el.tag
-        if tag == 't': parts.append(el.text or '')
-        elif tag in ('r', 'e', 'sub', 'sup', 'num', 'den', 'deg'):
-            for child in el: process(child)
-        elif tag.endswith('Pr'): pass
+        tag = el.tag.split("}")[-1] if "}" in el.tag else el.tag
+        if tag == "t":
+            parts.append(el.text or "")
+        elif tag in ("r", "e", "sub", "sup", "num", "den", "deg"):
+            for child in el:
+                process(child)
+        elif tag.endswith("Pr"):
+            pass
         else:
-            for child in el: process(child)
+            for child in el:
+                process(child)
+
     process(elem)
-    return ''.join(parts).strip()
+    return "".join(parts).strip()
 
 
 def omath_to_html(elem):
     parts = []
-    mns = 'http://schemas.openxmlformats.org/officeDocument/2006/math'
+    mns = "http://schemas.openxmlformats.org/officeDocument/2006/math"
+
     def process(el):
-        tag = el.tag.split('}')[-1] if '}' in el.tag else el.tag
-        if tag == 't': parts.append(html_mod.escape(el.text or ''))
-        elif tag == 'sSub':
-            base = el.find('m:e', ns); sub = el.find('m:sub', ns)
-            if base is not None: process(base)
+        tag = el.tag.split("}")[-1] if "}" in el.tag else el.tag
+        if tag == "t":
+            parts.append(html_mod.escape(el.text or ""))
+        elif tag == "sSub":
+            base = el.find("m:e", ns)
+            sub = el.find("m:sub", ns)
+            if base is not None:
+                process(base)
             if sub is not None:
-                parts.append(f'<sub>{html_mod.escape(omath_to_unicode_inner(sub))}</sub>')
-        elif tag == 'sSup':
-            base = el.find('m:e', ns); sup = el.find('m:sup', ns)
-            if base is not None: process(base)
+                parts.append(
+                    f"<sub>{html_mod.escape(omath_to_unicode_inner(sub))}</sub>"
+                )
+        elif tag == "sSup":
+            base = el.find("m:e", ns)
+            sup = el.find("m:sup", ns)
+            if base is not None:
+                process(base)
             if sup is not None:
-                parts.append(f'<sup>{html_mod.escape(omath_to_unicode_inner(sup))}</sup>')
-        elif tag == 'sSubSup':
-            base = el.find('m:e', ns); sub = el.find('m:sub', ns); sup = el.find('m:sup', ns)
-            if base is not None: process(base)
+                parts.append(
+                    f"<sup>{html_mod.escape(omath_to_unicode_inner(sup))}</sup>"
+                )
+        elif tag == "sSubSup":
+            base = el.find("m:e", ns)
+            sub = el.find("m:sub", ns)
+            sup = el.find("m:sup", ns)
+            if base is not None:
+                process(base)
             if sub is not None:
-                parts.append(f'<sub>{html_mod.escape(omath_to_unicode_inner(sub))}</sub>')
+                parts.append(
+                    f"<sub>{html_mod.escape(omath_to_unicode_inner(sub))}</sub>"
+                )
             if sup is not None:
-                parts.append(f'<sup>{html_mod.escape(omath_to_unicode_inner(sup))}</sup>')
-        elif tag == 'f':
-            num = el.find('m:num', ns); den = el.find('m:den', ns)
-            n = html_mod.escape(omath_to_unicode_inner(num)) if num is not None else ''
-            d = html_mod.escape(omath_to_unicode_inner(den)) if den is not None else ''
-            parts.append(f'({n})/({d})')
-        elif tag == 'rad':
-            base = el.find('m:e', ns)
-            parts.append('\u221a(')
-            if base is not None: process(base)
-            parts.append(')')
-        elif tag == 'nary':
-            chr_el = el.find('m:naryPr/m:chr', ns)
-            op = chr_el.get(f'{{{mns}}}val', '\u2211') if chr_el is not None else '\u2211'
-            sub = el.find('m:sub', ns); sup = el.find('m:sup', ns); base = el.find('m:e', ns)
+                parts.append(
+                    f"<sup>{html_mod.escape(omath_to_unicode_inner(sup))}</sup>"
+                )
+        elif tag == "f":
+            num = el.find("m:num", ns)
+            den = el.find("m:den", ns)
+            n = html_mod.escape(omath_to_unicode_inner(num)) if num is not None else ""
+            d = html_mod.escape(omath_to_unicode_inner(den)) if den is not None else ""
+            parts.append(f"({n})/({d})")
+        elif tag == "rad":
+            base = el.find("m:e", ns)
+            parts.append("\u221a(")
+            if base is not None:
+                process(base)
+            parts.append(")")
+        elif tag == "nary":
+            chr_el = el.find("m:naryPr/m:chr", ns)
+            op = (
+                chr_el.get(f"{{{mns}}}val", "\u2211")
+                if chr_el is not None
+                else "\u2211"
+            )
+            sub = el.find("m:sub", ns)
+            sup = el.find("m:sup", ns)
+            base = el.find("m:e", ns)
             parts.append(op)
             if sub is not None:
                 st = omath_to_unicode_inner(sub)
-                if st.strip(): parts.append(f'<sub>{html_mod.escape(st)}</sub>')
+                if st.strip():
+                    parts.append(f"<sub>{html_mod.escape(st)}</sub>")
             if sup is not None:
                 st = omath_to_unicode_inner(sup)
-                if st.strip(): parts.append(f'<sup>{html_mod.escape(st)}</sup>')
-            parts.append(' ')
-            if base is not None: process(base)
-        elif tag == 'd':
-            dPr = el.find('m:dPr', ns); beg, end = '(', ')'
+                if st.strip():
+                    parts.append(f"<sup>{html_mod.escape(st)}</sup>")
+            parts.append(" ")
+            if base is not None:
+                process(base)
+        elif tag == "d":
+            dPr = el.find("m:dPr", ns)
+            beg, end = "(", ")"
             if dPr is not None:
-                b = dPr.find('m:begChr', ns); e = dPr.find('m:endChr', ns)
-                if b is not None: beg = b.get(f'{{{mns}}}val', '(')
-                if e is not None: end = e.get(f'{{{mns}}}val', ')')
+                b = dPr.find("m:begChr", ns)
+                e = dPr.find("m:endChr", ns)
+                if b is not None:
+                    beg = b.get(f"{{{mns}}}val", "(")
+                if e is not None:
+                    end = e.get(f"{{{mns}}}val", ")")
             parts.append(html_mod.escape(beg))
-            e_els = el.findall('m:e', ns)
+            e_els = el.findall("m:e", ns)
             for idx, ee in enumerate(e_els):
-                if idx > 0: parts.append(', ')
+                if idx > 0:
+                    parts.append(", ")
                 process(ee)
             parts.append(html_mod.escape(end))
-        elif tag == 'acc':
-            base = el.find('m:e', ns)
-            if base is not None: process(base)
-        elif tag == 'bar':
-            base = el.find('m:e', ns)
-            if base is not None: process(base)
-        elif tag == 'eqArr':
-            for idx, ee in enumerate(el.findall('m:e', ns)):
-                if idx > 0: parts.append('<br>')
+        elif tag == "acc":
+            base = el.find("m:e", ns)
+            if base is not None:
+                process(base)
+        elif tag == "bar":
+            base = el.find("m:e", ns)
+            if base is not None:
+                process(base)
+        elif tag == "eqArr":
+            for idx, ee in enumerate(el.findall("m:e", ns)):
+                if idx > 0:
+                    parts.append("<br>")
                 process(ee)
-        elif tag in ('r', 'e', 'sub', 'sup', 'num', 'den', 'deg', 'oMath', 'oMathPara'):
-            for child in el: process(child)
-        elif tag.endswith('Pr'): pass
+        elif tag in ("r", "e", "sub", "sup", "num", "den", "deg", "oMath", "oMathPara"):
+            for child in el:
+                process(child)
+        elif tag.endswith("Pr"):
+            pass
         else:
-            for child in el: process(child)
+            for child in el:
+                process(child)
+
     process(elem)
-    return ''.join(parts).strip()
+    return "".join(parts).strip()
 
 
 def normalize(text):
-    t = re.sub(r'\s+', ' ', text).strip().lower()
-    t = t.replace('\u2013', '-').replace('\u2014', '-')
-    t = t.replace('\u2019', "'").replace('\u2018', "'")
-    t = t.replace('\u201c', '"').replace('\u201d', '"')
-    t = t.replace('\xa0', ' ')
+    t = re.sub(r"\s+", " ", text).strip().lower()
+    t = t.replace("\u2013", "-").replace("\u2014", "-")
+    t = t.replace("\u2019", "'").replace("\u2018", "'")
+    t = t.replace("\u201c", '"').replace("\u201d", '"')
+    t = t.replace("\xa0", " ")
     return t
 
 
@@ -128,27 +180,27 @@ def get_fragments(para_element):
     """Get ordered (type, content) fragments from a docx paragraph."""
     fragments = []
     for child in para_element:
-        tag = child.tag.split('}')[-1] if '}' in child.tag else child.tag
-        if tag == 'r':
-            rPr = child.find('w:rPr', ns)
-            is_bold = rPr is not None and rPr.find('w:b', ns) is not None
-            is_italic = rPr is not None and rPr.find('w:i', ns) is not None
-            t_el = child.find('w:t', ns)
+        tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+        if tag == "r":
+            rPr = child.find("w:rPr", ns)
+            is_bold = rPr is not None and rPr.find("w:b", ns) is not None
+            is_italic = rPr is not None and rPr.find("w:i", ns) is not None
+            t_el = child.find("w:t", ns)
             if t_el is not None and t_el.text:
-                fragments.append(('text', t_el.text, is_bold, is_italic))
-        elif tag == 'oMath':
+                fragments.append(("text", t_el.text, is_bold, is_italic))
+        elif tag == "oMath":
             math_html = omath_to_html(child)
             if math_html:
-                fragments.append(('math', math_html, False, True))
-        elif tag == 'oMathPara':
+                fragments.append(("math", math_html, False, True))
+        elif tag == "oMathPara":
             math_html = omath_to_html(child)
             if math_html:
-                fragments.append(('displaymath', math_html, False, False))
-        elif tag == 'hyperlink':
-            for r in child.findall('w:r', ns):
-                t_el = r.find('w:t', ns)
+                fragments.append(("displaymath", math_html, False, False))
+        elif tag == "hyperlink":
+            for r in child.findall("w:r", ns):
+                t_el = r.find("w:t", ns)
                 if t_el is not None and t_el.text:
-                    fragments.append(('text', t_el.text, False, False))
+                    fragments.append(("text", t_el.text, False, False))
     return fragments
 
 
@@ -163,25 +215,37 @@ def rebuild_from_fragments(fragments):
         is_bold = frag[2] if len(frag) > 2 else False
         is_italic = frag[3] if len(frag) > 3 else False
 
-        if ftype in ('math', 'displaymath'):
-            if in_italic: parts.append('</em>'); in_italic = False
-            if in_bold: parts.append('</strong>'); in_bold = False
+        if ftype in ("math", "displaymath"):
+            if in_italic:
+                parts.append("</em>")
+                in_italic = False
+            if in_bold:
+                parts.append("</strong>")
+                in_bold = False
             parts.append(f' <em class="math">{text}</em> ')
         else:
             if is_bold and not in_bold:
-                if in_italic: parts.append('</em>'); in_italic = False
-                parts.append('<strong>'); in_bold = True
+                if in_italic:
+                    parts.append("</em>")
+                    in_italic = False
+                parts.append("<strong>")
+                in_bold = True
             elif not is_bold and in_bold:
-                parts.append('</strong>'); in_bold = False
+                parts.append("</strong>")
+                in_bold = False
             if is_italic and not in_italic:
-                parts.append('<em>'); in_italic = True
+                parts.append("<em>")
+                in_italic = True
             elif not is_italic and in_italic:
-                parts.append('</em>'); in_italic = False
+                parts.append("</em>")
+                in_italic = False
             parts.append(html_mod.escape(text))
 
-    if in_italic: parts.append('</em>')
-    if in_bold: parts.append('</strong>')
-    return ''.join(parts)
+    if in_italic:
+        parts.append("</em>")
+    if in_bold:
+        parts.append("</strong>")
+    return "".join(parts)
 
 
 def build_docx_sequence(doc):
@@ -189,19 +253,21 @@ def build_docx_sequence(doc):
     sequence = []
     for p in doc.paragraphs:
         text = p.text.strip()
-        has_math = bool(p._element.findall('.//m:oMath', ns))
-        has_display = bool(p._element.findall('.//m:oMathPara', ns))
+        has_math = bool(p._element.findall(".//m:oMath", ns))
+        has_display = bool(p._element.findall(".//m:oMathPara", ns))
         is_math_only = has_display and not text
         fragments = get_fragments(p._element) if has_math else None
 
-        sequence.append({
-            'text': text,
-            'normalized': normalize(text) if text else '',
-            'has_math': has_math,
-            'is_display': has_display,
-            'is_math_only': is_math_only,
-            'fragments': fragments,
-        })
+        sequence.append(
+            {
+                "text": text,
+                "normalized": normalize(text) if text else "",
+                "has_math": has_math,
+                "is_display": has_display,
+                "is_math_only": is_math_only,
+                "fragments": fragments,
+            }
+        )
     return sequence
 
 
@@ -213,9 +279,9 @@ def find_html_line_by_text(lines, search_text, start_from=0):
 
     for i in range(start_from, len(lines)):
         line = lines[i]
-        if '<p ' not in line and '<li' not in line:
+        if "<p " not in line and "<li" not in line:
             continue
-        text_only = normalize(re.sub(r'<[^>]+>', '', line))
+        text_only = normalize(re.sub(r"<[^>]+>", "", line))
         if not text_only:
             continue
         # Check prefix match
@@ -234,9 +300,9 @@ def find_html_line_by_text(lines, search_text, start_from=0):
 
 def process_chapter(filepath, docx_seq, chapter_start, chapter_end):
     """Process a single chapter HTML file using the docx sequence."""
-    with open(filepath, 'r', encoding='utf-8') as f:
+    with open(filepath, "r", encoding="utf-8") as f:
         content = f.read()
-    lines = content.split('\n')
+    lines = content.split("\n")
 
     insertions = 0
     rebuilds = 0
@@ -248,13 +314,13 @@ def process_chapter(filepath, docx_seq, chapter_start, chapter_end):
     for di in range(chapter_start, chapter_end):
         entry = docx_seq[di]
 
-        if entry['is_math_only']:
+        if entry["is_math_only"]:
             # This is a display equation - need to INSERT a new paragraph
             # Find the preceding text paragraph in the docx
-            prev_text = ''
+            prev_text = ""
             for pi in range(di - 1, max(chapter_start - 1, di - 5), -1):
-                if docx_seq[pi]['text'] and not docx_seq[pi]['is_math_only']:
-                    prev_text = docx_seq[pi]['text']
+                if docx_seq[pi]["text"] and not docx_seq[pi]["is_math_only"]:
+                    prev_text = docx_seq[pi]["text"]
                     break
 
             if not prev_text:
@@ -266,7 +332,9 @@ def process_chapter(filepath, docx_seq, chapter_start, chapter_end):
                 continue
 
             # Build the display equation HTML
-            math_html = omath_to_html(entry['fragments'][0][1]) if entry['fragments'] else ''
+            math_html = (
+                omath_to_html(entry["fragments"][0][1]) if entry["fragments"] else ""
+            )
             if not math_html:
                 # Get math directly from the element
                 for p in [docx_seq[di]]:
@@ -282,33 +350,39 @@ def process_chapter(filepath, docx_seq, chapter_start, chapter_end):
             insertions += 1
             html_cursor = html_idx + 1
 
-        elif entry['has_math'] and entry['fragments']:
+        elif entry["has_math"] and entry["fragments"]:
             # Paragraph with inline math - check if HTML version is missing math
-            html_idx = find_html_line_by_text(new_lines, entry['text'], html_cursor)
+            html_idx = find_html_line_by_text(new_lines, entry["text"], html_cursor)
             if html_idx < 0:
                 continue
 
-            html_line = new_lines[html_idx + offset] if html_idx + offset < len(new_lines) else ''
-            text_only = re.sub(r'<[^>]+>', '', html_line)
+            html_line = (
+                new_lines[html_idx + offset]
+                if html_idx + offset < len(new_lines)
+                else ""
+            )
+            text_only = re.sub(r"<[^>]+>", "", html_line)
 
             # Check if this line still has missing math (double spaces or single-space gaps)
-            has_gaps = ('  ' in text_only or
-                       re.search(r'\b[A-Za-z] [,.]', text_only) is not None)
+            has_gaps = (
+                "  " in text_only
+                or re.search(r"\b[A-Za-z] [,.]", text_only) is not None
+            )
 
             if has_gaps and 'class="math"' not in html_line:
                 # Rebuild the paragraph from docx fragments
-                tag_match = re.match(r'(<p[^>]*>)', html_line)
+                tag_match = re.match(r"(<p[^>]*>)", html_line)
                 if tag_match:
                     open_tag = tag_match.group(1)
-                    rebuilt = rebuild_from_fragments(entry['fragments'])
-                    new_lines[html_idx + offset] = f'{open_tag}{rebuilt}</p>'
+                    rebuilt = rebuild_from_fragments(entry["fragments"])
+                    new_lines[html_idx + offset] = f"{open_tag}{rebuilt}</p>"
                     rebuilds += 1
 
             html_cursor = html_idx + 1
 
     if insertions > 0 or rebuilds > 0:
-        with open(filepath, 'w', encoding='utf-8', newline='\n') as f:
-            f.write('\n'.join(new_lines))
+        with open(filepath, "w", encoding="utf-8", newline="\n") as f:
+            f.write("\n".join(new_lines))
 
     return insertions, rebuilds
 
@@ -318,18 +392,18 @@ def find_chapter_boundaries(docx_seq):
     chapters = {}
     current_chapter = None
     for i, entry in enumerate(docx_seq):
-        text = entry['text']
-        if text.startswith('Chapter ') and ':' in text[:30]:
-            ch_match = re.match(r'Chapter (\d+)', text)
+        text = entry["text"]
+        if text.startswith("Chapter ") and ":" in text[:30]:
+            ch_match = re.match(r"Chapter (\d+)", text)
             if ch_match:
                 ch_num = int(ch_match.group(1))
                 if current_chapter is not None:
-                    chapters[current_chapter]['end'] = i
+                    chapters[current_chapter]["end"] = i
                 current_chapter = ch_num
-                chapters[ch_num] = {'start': i, 'end': len(docx_seq)}
-        elif text.startswith('Appendix '):
+                chapters[ch_num] = {"start": i, "end": len(docx_seq)}
+        elif text.startswith("Appendix "):
             if current_chapter is not None:
-                chapters[current_chapter]['end'] = i
+                chapters[current_chapter]["end"] = i
                 current_chapter = None
 
     return chapters
@@ -338,7 +412,7 @@ def find_chapter_boundaries(docx_seq):
 # Map chapter numbers to HTML filenames
 CHAPTER_FILES = {}
 for fname in os.listdir(BOOK_DIR):
-    m = re.match(r'chapter-(\d+)-', fname)
+    m = re.match(r"chapter-(\d+)-", fname)
     if m:
         CHAPTER_FILES[int(m.group(1))] = fname
 
@@ -351,7 +425,7 @@ def main():
     print(f"  {len(docx_seq)} total paragraphs")
 
     # Count display equations
-    display_count = sum(1 for e in docx_seq if e['is_math_only'])
+    display_count = sum(1 for e in docx_seq if e["is_math_only"])
     print(f"  {display_count} display equations to insert")
 
     chapters = find_chapter_boundaries(docx_seq)
@@ -361,17 +435,17 @@ def main():
     # since fragments may not capture oMathPara correctly
     # Re-extract: for each math-only paragraph, get the math HTML
     for i, entry in enumerate(docx_seq):
-        if entry['is_math_only']:
+        if entry["is_math_only"]:
             para_el = doc.paragraphs[i]._element
-            omath_els = para_el.findall('.//m:oMath', ns)
+            omath_els = para_el.findall(".//m:oMath", ns)
             if omath_els:
-                combined = ' '.join(omath_to_html(om) for om in omath_els)
-                entry['display_html'] = combined
+                combined = " ".join(omath_to_html(om) for om in omath_els)
+                entry["display_html"] = combined
             else:
-                omathpara_els = para_el.findall('.//m:oMathPara', ns)
+                omathpara_els = para_el.findall(".//m:oMathPara", ns)
                 if omathpara_els:
-                    combined = ' '.join(omath_to_html(om) for om in omathpara_els)
-                    entry['display_html'] = combined
+                    combined = " ".join(omath_to_html(om) for om in omathpara_els)
+                    entry["display_html"] = combined
 
     total_insertions = 0
     total_rebuilds = 0
@@ -382,12 +456,12 @@ def main():
 
         fname = CHAPTER_FILES[ch_num]
         filepath = os.path.join(BOOK_DIR, fname)
-        ch_start = chapters[ch_num]['start']
-        ch_end = chapters[ch_num]['end']
+        ch_start = chapters[ch_num]["start"]
+        ch_end = chapters[ch_num]["end"]
 
-        with open(filepath, 'r', encoding='utf-8') as f:
+        with open(filepath, "r", encoding="utf-8") as f:
             content = f.read()
-        lines = content.split('\n')
+        lines = content.split("\n")
 
         insertions = 0
         rebuilds = 0
@@ -398,12 +472,12 @@ def main():
         for di in range(ch_start, ch_end):
             entry = docx_seq[di]
 
-            if entry['is_math_only'] and 'display_html' in entry:
+            if entry["is_math_only"] and "display_html" in entry:
                 # Find preceding non-math paragraph
-                prev_text = ''
+                prev_text = ""
                 for pi in range(di - 1, max(ch_start - 1, di - 5), -1):
-                    if docx_seq[pi]['text'] and not docx_seq[pi]['is_math_only']:
-                        prev_text = docx_seq[pi]['text']
+                    if docx_seq[pi]["text"] and not docx_seq[pi]["is_math_only"]:
+                        prev_text = docx_seq[pi]["text"]
                         break
                 if not prev_text:
                     continue
@@ -414,19 +488,19 @@ def main():
 
                 # Check if equation already exists after this line
                 next_idx = html_idx + 1 + offset
-                if next_idx < len(new_lines) and 'display-math' in new_lines[next_idx]:
+                if next_idx < len(new_lines) and "display-math" in new_lines[next_idx]:
                     html_cursor = html_idx + 1
                     continue
 
-                eq_html = entry['display_html']
+                eq_html = entry["display_html"]
                 eq_line = f'<p class="display-math"><em class="math">{eq_html}</em></p>'
                 new_lines.insert(html_idx + 1 + offset, eq_line)
                 offset += 1
                 insertions += 1
                 html_cursor = html_idx + 1
 
-            elif entry['has_math'] and entry['text']:
-                html_idx = find_html_line_by_text(new_lines, entry['text'], html_cursor)
+            elif entry["has_math"] and entry["text"]:
+                html_idx = find_html_line_by_text(new_lines, entry["text"], html_cursor)
                 if html_idx < 0:
                     continue
 
@@ -434,42 +508,45 @@ def main():
                 if actual_idx >= len(new_lines):
                     continue
                 html_line = new_lines[actual_idx]
-                text_only = re.sub(r'<[^>]+>', '', html_line)
+                text_only = re.sub(r"<[^>]+>", "", html_line)
 
                 # Check for remaining gaps
-                has_gaps = ('  ' in text_only or
-                           re.search(r'(?<=[a-z]) [,.]', text_only))
+                has_gaps = "  " in text_only or re.search(r"(?<=[a-z]) [,.]", text_only)
 
-                if has_gaps and 'class="math"' not in html_line and entry['fragments']:
-                    tag_match = re.match(r'(<p[^>]*>)', html_line)
+                if has_gaps and 'class="math"' not in html_line and entry["fragments"]:
+                    tag_match = re.match(r"(<p[^>]*>)", html_line)
                     if tag_match:
                         open_tag = tag_match.group(1)
-                        rebuilt = rebuild_from_fragments(entry['fragments'])
+                        rebuilt = rebuild_from_fragments(entry["fragments"])
                         if 'class="math"' in rebuilt:
-                            new_lines[actual_idx] = f'{open_tag}{rebuilt}</p>'
+                            new_lines[actual_idx] = f"{open_tag}{rebuilt}</p>"
                             rebuilds += 1
 
                 html_cursor = html_idx + 1
 
         if insertions > 0 or rebuilds > 0:
-            with open(filepath, 'w', encoding='utf-8', newline='\n') as f:
-                f.write('\n'.join(new_lines))
-            print(f"  {fname}: {insertions} equations inserted, {rebuilds} paragraphs rebuilt")
+            with open(filepath, "w", encoding="utf-8", newline="\n") as f:
+                f.write("\n".join(new_lines))
+            print(
+                f"  {fname}: {insertions} equations inserted, {rebuilds} paragraphs rebuilt"
+            )
             total_insertions += insertions
             total_rebuilds += rebuilds
 
-    print(f"\nTotal: {total_insertions} display equations inserted, {total_rebuilds} paragraphs rebuilt")
+    print(
+        f"\nTotal: {total_insertions} display equations inserted, {total_rebuilds} paragraphs rebuilt"
+    )
 
     # Add display-math CSS
-    css_path = os.path.join(BOOK_DIR, 'book.css')
-    with open(css_path, 'r', encoding='utf-8') as f:
+    css_path = os.path.join(BOOK_DIR, "book.css")
+    with open(css_path, "r", encoding="utf-8") as f:
         css = f.read()
-    if '.display-math' not in css:
+    if ".display-math" not in css:
         css += '\n\n/* Display equations */\np.display-math { text-align: center; margin: 1.2em 0; font-size: 1.1em; }\np.display-math em.math { font-style: italic; font-family: "Cambria Math", "STIX Two Math", serif; }\n'
-        with open(css_path, 'w', encoding='utf-8') as f:
+        with open(css_path, "w", encoding="utf-8") as f:
             f.write(css)
         print("Added .display-math CSS to book.css")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/fix_math_rebuild.py
+++ b/fix_math_rebuild.py
@@ -19,240 +19,281 @@ HTML chapter 29 = docx chapter 20
 HTML chapter 30 = docx chapter 21
 """
 
-import sys, io, re, os, html as html_mod
-sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+import html as html_mod
+import io
+import os
+import re
+import sys
 
-from docx import Document
-import lxml.etree as ET
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
 
-BOOK_DIR = r'C:\source\erisml-lib\docs\book'
-DOCX_PATH = r'C:\source\erisml-lib\docs\papers\foundations\Geometric Ethics - The Mathematical Structure of Moral Reasoning - Bond - v1.14 - Mar 2026.docx'
+from docx import Document  # noqa: E402
 
-ns = {'m': 'http://schemas.openxmlformats.org/officeDocument/2006/math',
-      'w': 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'}
+BOOK_DIR = r"C:\source\erisml-lib\docs\book"
+DOCX_PATH = r"C:\source\erisml-lib\docs\papers\foundations\Geometric Ethics - The Mathematical Structure of Moral Reasoning - Bond - v1.14 - Mar 2026.docx"
 
-MNS = 'http://schemas.openxmlformats.org/officeDocument/2006/math'
+ns = {
+    "m": "http://schemas.openxmlformats.org/officeDocument/2006/math",
+    "w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+}
+
+MNS = "http://schemas.openxmlformats.org/officeDocument/2006/math"
 
 # ─── omath converter ─────────────────────────────────────────────────
+
 
 def omath_to_unicode_inner(elem):
     """Extract plain-text content from an Office MathML element."""
     parts = []
+
     def process(el):
-        tag = el.tag.split('}')[-1] if '}' in el.tag else el.tag
-        if tag == 't':
-            parts.append(el.text or '')
-        elif tag.endswith('Pr'):
+        tag = el.tag.split("}")[-1] if "}" in el.tag else el.tag
+        if tag == "t":
+            parts.append(el.text or "")
+        elif tag.endswith("Pr"):
             pass
         else:
             for child in el:
                 process(child)
+
     process(elem)
-    return ''.join(parts).strip()
+    return "".join(parts).strip()
 
 
 def omath_to_html(elem):
     """Convert Office MathML element to HTML with sub/sup tags."""
     parts = []
+
     def process(el):
-        tag = el.tag.split('}')[-1] if '}' in el.tag else el.tag
-        if tag == 't':
-            parts.append(html_mod.escape(el.text or ''))
-        elif tag == 'sSub':
-            base = el.find('m:e', ns)
-            sub = el.find('m:sub', ns)
+        tag = el.tag.split("}")[-1] if "}" in el.tag else el.tag
+        if tag == "t":
+            parts.append(html_mod.escape(el.text or ""))
+        elif tag == "sSub":
+            base = el.find("m:e", ns)
+            sub = el.find("m:sub", ns)
             if base is not None:
                 process(base)
             if sub is not None:
-                parts.append(f'<sub>{html_mod.escape(omath_to_unicode_inner(sub))}</sub>')
-        elif tag == 'sSup':
-            base = el.find('m:e', ns)
-            sup = el.find('m:sup', ns)
+                parts.append(
+                    f"<sub>{html_mod.escape(omath_to_unicode_inner(sub))}</sub>"
+                )
+        elif tag == "sSup":
+            base = el.find("m:e", ns)
+            sup = el.find("m:sup", ns)
             if base is not None:
                 process(base)
             if sup is not None:
-                parts.append(f'<sup>{html_mod.escape(omath_to_unicode_inner(sup))}</sup>')
-        elif tag == 'sSubSup':
-            base = el.find('m:e', ns)
-            sub = el.find('m:sub', ns)
-            sup = el.find('m:sup', ns)
+                parts.append(
+                    f"<sup>{html_mod.escape(omath_to_unicode_inner(sup))}</sup>"
+                )
+        elif tag == "sSubSup":
+            base = el.find("m:e", ns)
+            sub = el.find("m:sub", ns)
+            sup = el.find("m:sup", ns)
             if base is not None:
                 process(base)
             if sub is not None:
-                parts.append(f'<sub>{html_mod.escape(omath_to_unicode_inner(sub))}</sub>')
+                parts.append(
+                    f"<sub>{html_mod.escape(omath_to_unicode_inner(sub))}</sub>"
+                )
             if sup is not None:
-                parts.append(f'<sup>{html_mod.escape(omath_to_unicode_inner(sup))}</sup>')
-        elif tag == 'f':
-            num = el.find('m:num', ns)
-            den = el.find('m:den', ns)
-            n = html_mod.escape(omath_to_unicode_inner(num)) if num is not None else ''
-            d = html_mod.escape(omath_to_unicode_inner(den)) if den is not None else ''
-            parts.append(f'({n})/({d})')
-        elif tag == 'rad':
-            base = el.find('m:e', ns)
-            parts.append('\u221a(')
+                parts.append(
+                    f"<sup>{html_mod.escape(omath_to_unicode_inner(sup))}</sup>"
+                )
+        elif tag == "f":
+            num = el.find("m:num", ns)
+            den = el.find("m:den", ns)
+            n = html_mod.escape(omath_to_unicode_inner(num)) if num is not None else ""
+            d = html_mod.escape(omath_to_unicode_inner(den)) if den is not None else ""
+            parts.append(f"({n})/({d})")
+        elif tag == "rad":
+            base = el.find("m:e", ns)
+            parts.append("\u221a(")
             if base is not None:
                 process(base)
-            parts.append(')')
-        elif tag == 'nary':
-            chr_el = el.find('m:naryPr/m:chr', ns)
-            op = chr_el.get(f'{{{MNS}}}val', '\u2211') if chr_el is not None else '\u2211'
-            sub = el.find('m:sub', ns)
-            sup = el.find('m:sup', ns)
-            base = el.find('m:e', ns)
+            parts.append(")")
+        elif tag == "nary":
+            chr_el = el.find("m:naryPr/m:chr", ns)
+            op = (
+                chr_el.get(f"{{{MNS}}}val", "\u2211")
+                if chr_el is not None
+                else "\u2211"
+            )
+            sub = el.find("m:sub", ns)
+            sup = el.find("m:sup", ns)
+            base = el.find("m:e", ns)
             parts.append(op)
             if sub is not None:
                 st = omath_to_unicode_inner(sub)
                 if st.strip():
-                    parts.append(f'<sub>{html_mod.escape(st)}</sub>')
+                    parts.append(f"<sub>{html_mod.escape(st)}</sub>")
             if sup is not None:
                 st = omath_to_unicode_inner(sup)
                 if st.strip():
-                    parts.append(f'<sup>{html_mod.escape(st)}</sup>')
-            parts.append(' ')
+                    parts.append(f"<sup>{html_mod.escape(st)}</sup>")
+            parts.append(" ")
             if base is not None:
                 process(base)
-        elif tag == 'd':
-            dPr = el.find('m:dPr', ns)
-            beg, end = '(', ')'
+        elif tag == "d":
+            dPr = el.find("m:dPr", ns)
+            beg, end = "(", ")"
             if dPr is not None:
-                b = dPr.find('m:begChr', ns)
-                e = dPr.find('m:endChr', ns)
+                b = dPr.find("m:begChr", ns)
+                e = dPr.find("m:endChr", ns)
                 if b is not None:
-                    beg = b.get(f'{{{MNS}}}val', '(')
+                    beg = b.get(f"{{{MNS}}}val", "(")
                 if e is not None:
-                    end = e.get(f'{{{MNS}}}val', ')')
+                    end = e.get(f"{{{MNS}}}val", ")")
             parts.append(html_mod.escape(beg))
-            e_els = el.findall('m:e', ns)
+            e_els = el.findall("m:e", ns)
             for idx, ee in enumerate(e_els):
                 if idx > 0:
-                    parts.append(', ')
+                    parts.append(", ")
                 process(ee)
             parts.append(html_mod.escape(end))
-        elif tag == 'acc':
-            base = el.find('m:e', ns)
+        elif tag == "acc":
+            base = el.find("m:e", ns)
             if base is not None:
                 process(base)
-        elif tag == 'bar':
-            base = el.find('m:e', ns)
+        elif tag == "bar":
+            base = el.find("m:e", ns)
             if base is not None:
                 process(base)
-        elif tag == 'eqArr':
-            for idx, ee in enumerate(el.findall('m:e', ns)):
+        elif tag == "eqArr":
+            for idx, ee in enumerate(el.findall("m:e", ns)):
                 if idx > 0:
-                    parts.append('<br>')
+                    parts.append("<br>")
                 process(ee)
-        elif tag == 'limLow':
-            base = el.find('m:e', ns)
-            lim = el.find('m:lim', ns)
+        elif tag == "limLow":
+            base = el.find("m:e", ns)
+            lim = el.find("m:lim", ns)
             if base is not None:
                 process(base)
             if lim is not None:
-                parts.append(f'<sub>{html_mod.escape(omath_to_unicode_inner(lim))}</sub>')
-        elif tag == 'limUpp':
-            base = el.find('m:e', ns)
-            lim = el.find('m:lim', ns)
+                parts.append(
+                    f"<sub>{html_mod.escape(omath_to_unicode_inner(lim))}</sub>"
+                )
+        elif tag == "limUpp":
+            base = el.find("m:e", ns)
+            lim = el.find("m:lim", ns)
             if base is not None:
                 process(base)
             if lim is not None:
-                parts.append(f'<sup>{html_mod.escape(omath_to_unicode_inner(lim))}</sup>')
-        elif tag == 'func':
-            fname = el.find('m:fName', ns)
-            base = el.find('m:e', ns)
+                parts.append(
+                    f"<sup>{html_mod.escape(omath_to_unicode_inner(lim))}</sup>"
+                )
+        elif tag == "func":
+            fname = el.find("m:fName", ns)
+            base = el.find("m:e", ns)
             if fname is not None:
                 process(fname)
             if base is not None:
-                parts.append(' ')
+                parts.append(" ")
                 process(base)
-        elif tag == 'm':
+        elif tag == "m":
             # Matrix
-            rows = el.findall('m:mr', ns)
-            parts.append('[')
+            rows = el.findall("m:mr", ns)
+            parts.append("[")
             for ri, row in enumerate(rows):
                 if ri > 0:
-                    parts.append('; ')
-                e_els = row.findall('m:e', ns)
+                    parts.append("; ")
+                e_els = row.findall("m:e", ns)
                 for ci, ce in enumerate(e_els):
                     if ci > 0:
-                        parts.append(', ')
+                        parts.append(", ")
                     process(ce)
-            parts.append(']')
-        elif tag == 'box':
-            base = el.find('m:e', ns)
+            parts.append("]")
+        elif tag == "box":
+            base = el.find("m:e", ns)
             if base is not None:
                 process(base)
-        elif tag == 'borderBox':
-            base = el.find('m:e', ns)
+        elif tag == "borderBox":
+            base = el.find("m:e", ns)
             if base is not None:
                 process(base)
-        elif tag == 'groupChr':
-            base = el.find('m:e', ns)
+        elif tag == "groupChr":
+            base = el.find("m:e", ns)
             if base is not None:
                 process(base)
-        elif tag == 'phant':
-            base = el.find('m:e', ns)
+        elif tag == "phant":
+            base = el.find("m:e", ns)
             if base is not None:
                 process(base)
-        elif tag in ('r', 'e', 'sub', 'sup', 'num', 'den', 'deg', 'oMath', 'oMathPara', 'lim', 'fName'):
+        elif tag in (
+            "r",
+            "e",
+            "sub",
+            "sup",
+            "num",
+            "den",
+            "deg",
+            "oMath",
+            "oMathPara",
+            "lim",
+            "fName",
+        ):
             for child in el:
                 process(child)
-        elif tag.endswith('Pr'):
+        elif tag.endswith("Pr"):
             pass
         else:
             for child in el:
                 process(child)
+
     process(elem)
-    return ''.join(parts).strip()
+    return "".join(parts).strip()
 
 
 # ─── text normalization ───────────────────────────────────────────────
 
+
 def normalize(text):
     """Normalize text for matching: collapse whitespace, replace special chars."""
-    t = re.sub(r'\s+', ' ', text).strip().lower()
-    t = t.replace('\u2013', '-').replace('\u2014', '-')
-    t = t.replace('\u2019', "'").replace('\u2018', "'")
-    t = t.replace('\u201c', '"').replace('\u201d', '"')
-    t = t.replace('\xa0', ' ')
-    t = re.sub(r'\s+', ' ', t).strip()
+    t = re.sub(r"\s+", " ", text).strip().lower()
+    t = t.replace("\u2013", "-").replace("\u2014", "-")
+    t = t.replace("\u2019", "'").replace("\u2018", "'")
+    t = t.replace("\u201c", '"').replace("\u201d", '"')
+    t = t.replace("\xa0", " ")
+    t = re.sub(r"\s+", " ", t).strip()
     return t
 
 
 def strip_html_tags(html_text):
     """Remove all HTML tags and return plain text."""
-    return re.sub(r'<[^>]+>', '', html_text)
+    return re.sub(r"<[^>]+>", "", html_text)
 
 
 # ─── docx paragraph parsing ──────────────────────────────────────────
+
 
 def get_fragments(para_element):
     """Get ordered (type, content, is_bold, is_italic) fragments from a docx paragraph XML."""
     fragments = []
     for child in para_element:
-        tag = child.tag.split('}')[-1] if '}' in child.tag else child.tag
-        if tag == 'r':
-            rPr = child.find('w:rPr', ns)
-            is_bold = rPr is not None and rPr.find('w:b', ns) is not None
-            is_italic = rPr is not None and rPr.find('w:i', ns) is not None
-            t_el = child.find('w:t', ns)
+        tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+        if tag == "r":
+            rPr = child.find("w:rPr", ns)
+            is_bold = rPr is not None and rPr.find("w:b", ns) is not None
+            is_italic = rPr is not None and rPr.find("w:i", ns) is not None
+            t_el = child.find("w:t", ns)
             if t_el is not None and t_el.text:
-                fragments.append(('text', t_el.text, is_bold, is_italic))
-        elif tag == 'oMath':
+                fragments.append(("text", t_el.text, is_bold, is_italic))
+        elif tag == "oMath":
             math_html = omath_to_html(child)
             if math_html:
-                fragments.append(('math', math_html, False, True))
-        elif tag == 'oMathPara':
+                fragments.append(("math", math_html, False, True))
+        elif tag == "oMathPara":
             math_html = omath_to_html(child)
             if math_html:
-                fragments.append(('displaymath', math_html, False, False))
-        elif tag == 'hyperlink':
-            for r in child.findall('w:r', ns):
-                rPr = r.find('w:rPr', ns)
-                is_bold = rPr is not None and rPr.find('w:b', ns) is not None
-                is_italic = rPr is not None and rPr.find('w:i', ns) is not None
-                t_el = r.find('w:t', ns)
+                fragments.append(("displaymath", math_html, False, False))
+        elif tag == "hyperlink":
+            for r in child.findall("w:r", ns):
+                rPr = r.find("w:rPr", ns)
+                is_bold = rPr is not None and rPr.find("w:b", ns) is not None
+                is_italic = rPr is not None and rPr.find("w:i", ns) is not None
+                t_el = r.find("w:t", ns)
                 if t_el is not None and t_el.text:
-                    fragments.append(('text', t_el.text, is_bold, is_italic))
+                    fragments.append(("text", t_el.text, is_bold, is_italic))
     return fragments
 
 
@@ -260,19 +301,19 @@ def get_para_text(para_element):
     """Get plain text from a paragraph element including math text."""
     parts = []
     for child in para_element:
-        tag = child.tag.split('}')[-1] if '}' in child.tag else child.tag
-        if tag == 'r':
-            t_el = child.find('w:t', ns)
+        tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+        if tag == "r":
+            t_el = child.find("w:t", ns)
             if t_el is not None and t_el.text:
                 parts.append(t_el.text)
-        elif tag in ('oMath', 'oMathPara'):
+        elif tag in ("oMath", "oMathPara"):
             parts.append(omath_to_unicode_inner(child))
-        elif tag == 'hyperlink':
-            for r in child.findall('w:r', ns):
-                t_el = r.find('w:t', ns)
+        elif tag == "hyperlink":
+            for r in child.findall("w:r", ns):
+                t_el = r.find("w:t", ns)
                 if t_el is not None and t_el.text:
                     parts.append(t_el.text)
-    return ''.join(parts).strip()
+    return "".join(parts).strip()
 
 
 def rebuild_from_fragments(fragments):
@@ -286,59 +327,72 @@ def rebuild_from_fragments(fragments):
         is_bold = frag[2] if len(frag) > 2 else False
         is_italic = frag[3] if len(frag) > 3 else False
 
-        if ftype in ('math', 'displaymath'):
+        if ftype in ("math", "displaymath"):
             # Close any open formatting tags before math
             if in_italic:
-                parts.append('</em>')
+                parts.append("</em>")
                 in_italic = False
             if in_bold:
-                parts.append('</strong>')
+                parts.append("</strong>")
                 in_bold = False
             # Add space before math only if needed (previous part doesn't end with space)
-            prev = ''.join(parts)
-            if prev and not prev.endswith(' ') and not prev.endswith('>'):
-                parts.append(' ')
+            prev = "".join(parts)
+            if prev and not prev.endswith(" ") and not prev.endswith(">"):
+                parts.append(" ")
             parts.append(f'<em class="math">{text}</em>')
             # Add space after math only if next fragment doesn't start with space/punctuation
             if fi + 1 < len(fragments):
                 next_frag = fragments[fi + 1]
                 next_text = next_frag[1]
-                if next_frag[0] in ('math', 'displaymath'):
-                    parts.append(' ')
-                elif next_text and not next_text[0] in (' ', ',', '.', ':', ';', ')', ']', '!', '?', '\u2019', '\u201d'):
-                    parts.append(' ')
+                if next_frag[0] in ("math", "displaymath"):
+                    parts.append(" ")
+                elif next_text and next_text[0] not in (
+                    " ",
+                    ",",
+                    ".",
+                    ":",
+                    ";",
+                    ")",
+                    "]",
+                    "!",
+                    "?",
+                    "\u2019",
+                    "\u201d",
+                ):
+                    parts.append(" ")
             # Don't add trailing space at end of content
         else:
             # Handle bold transitions
             if is_bold and not in_bold:
                 if in_italic:
-                    parts.append('</em>')
+                    parts.append("</em>")
                     in_italic = False
-                parts.append('<strong>')
+                parts.append("<strong>")
                 in_bold = True
             elif not is_bold and in_bold:
-                parts.append('</strong>')
+                parts.append("</strong>")
                 in_bold = False
             # Handle italic transitions
             if is_italic and not in_italic:
-                parts.append('<em>')
+                parts.append("<em>")
                 in_italic = True
             elif not is_italic and in_italic:
-                parts.append('</em>')
+                parts.append("</em>")
                 in_italic = False
             parts.append(html_mod.escape(text))
 
     if in_italic:
-        parts.append('</em>')
+        parts.append("</em>")
     if in_bold:
-        parts.append('</strong>')
-    result = ''.join(parts)
+        parts.append("</strong>")
+    result = "".join(parts)
     # Clean up any remaining double spaces
-    result = re.sub(r'  +', ' ', result)
+    result = re.sub(r"  +", " ", result)
     return result
 
 
 # ─── docx chapter building ───────────────────────────────────────────
+
 
 def build_docx_chapters(doc):
     """
@@ -350,8 +404,8 @@ def build_docx_chapters(doc):
         el = p._element
         text = p.text.strip()
 
-        has_math = bool(el.findall('.//m:oMath', ns))
-        has_display = bool(el.findall('.//m:oMathPara', ns))
+        has_math = bool(el.findall(".//m:oMath", ns))
+        has_display = bool(el.findall(".//m:oMathPara", ns))
 
         # A display-only paragraph: m:oMathPara present, and no text outside math
         text_without_math = get_text_without_math(el)
@@ -362,54 +416,58 @@ def build_docx_chapters(doc):
         # Get display HTML directly from XML for display-only paragraphs
         display_html = None
         if is_display_only:
-            omath_els = el.findall('.//m:oMath', ns)
+            omath_els = el.findall(".//m:oMath", ns)
             if omath_els:
-                display_html = ' '.join(omath_to_html(om) for om in omath_els)
+                display_html = " ".join(omath_to_html(om) for om in omath_els)
             else:
-                omathpara_els = el.findall('.//m:oMathPara', ns)
+                omathpara_els = el.findall(".//m:oMathPara", ns)
                 if omathpara_els:
-                    display_html = ' '.join(omath_to_html(om) for om in omathpara_els)
+                    display_html = " ".join(omath_to_html(om) for om in omathpara_els)
 
         # Determine if this is a heading
-        style_el = el.find('w:pPr/w:pStyle', ns)
-        style_name = style_el.get(f'{{{ns["w"]}}}val', '') if style_el is not None else ''
-        is_heading = 'Heading' in style_name or style_name.startswith('heading')
+        style_el = el.find("w:pPr/w:pStyle", ns)
+        style_name = (
+            style_el.get(f'{{{ns["w"]}}}val', "") if style_el is not None else ""
+        )
+        is_heading = "Heading" in style_name or style_name.startswith("heading")
 
-        all_paras.append({
-            'text': text,
-            'text_full': get_para_text(el),  # includes math text
-            'normalized': normalize(text) if text else '',
-            'norm_full': normalize(get_para_text(el)),
-            'has_math': has_math,
-            'has_display': has_display,
-            'is_display_only': is_display_only,
-            'display_html': display_html,
-            'fragments': fragments,
-            'is_heading': is_heading,
-            'style': style_name,
-        })
+        all_paras.append(
+            {
+                "text": text,
+                "text_full": get_para_text(el),  # includes math text
+                "normalized": normalize(text) if text else "",
+                "norm_full": normalize(get_para_text(el)),
+                "has_math": has_math,
+                "has_display": has_display,
+                "is_display_only": is_display_only,
+                "display_html": display_html,
+                "fragments": fragments,
+                "is_heading": is_heading,
+                "style": style_name,
+            }
+        )
 
     # Find chapter boundaries
     chapters = {}
     current_chapter = None
     for i, entry in enumerate(all_paras):
-        text = entry['text']
-        if text.startswith('Chapter ') and ':' in text[:30]:
-            ch_match = re.match(r'Chapter (\d+)', text)
+        text = entry["text"]
+        if text.startswith("Chapter ") and ":" in text[:30]:
+            ch_match = re.match(r"Chapter (\d+)", text)
             if ch_match:
                 ch_num = int(ch_match.group(1))
                 if current_chapter is not None:
-                    chapters[current_chapter] = all_paras[chapters[current_chapter]:i]
+                    chapters[current_chapter] = all_paras[chapters[current_chapter] : i]
                 chapters[ch_num] = i  # temporarily store start index
                 current_chapter = ch_num
-        elif text.startswith('Appendix ') and ':' in text[:30]:
+        elif text.startswith("Appendix ") and ":" in text[:30]:
             if current_chapter is not None:
-                chapters[current_chapter] = all_paras[chapters[current_chapter]:i]
+                chapters[current_chapter] = all_paras[chapters[current_chapter] : i]
                 current_chapter = None
 
     # Close last chapter
     if current_chapter is not None:
-        chapters[current_chapter] = all_paras[chapters[current_chapter]:]
+        chapters[current_chapter] = all_paras[chapters[current_chapter] :]
 
     return chapters
 
@@ -418,20 +476,21 @@ def get_text_without_math(para_element):
     """Get text content from paragraph excluding math elements."""
     parts = []
     for child in para_element:
-        tag = child.tag.split('}')[-1] if '}' in child.tag else child.tag
-        if tag == 'r':
-            t_el = child.find('w:t', ns)
+        tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+        if tag == "r":
+            t_el = child.find("w:t", ns)
             if t_el is not None and t_el.text:
                 parts.append(t_el.text)
-        elif tag == 'hyperlink':
-            for r in child.findall('w:r', ns):
-                t_el = r.find('w:t', ns)
+        elif tag == "hyperlink":
+            for r in child.findall("w:r", ns):
+                t_el = r.find("w:t", ns)
                 if t_el is not None and t_el.text:
                     parts.append(t_el.text)
-    return ''.join(parts)
+    return "".join(parts)
 
 
 # ─── HTML paragraph matching ─────────────────────────────────────────
+
 
 def html_line_text(line):
     """Extract plain text from an HTML line, stripping tags."""
@@ -440,7 +499,7 @@ def html_line_text(line):
 
 def is_heading_line(line):
     """Check if an HTML line is a heading."""
-    return bool(re.match(r'<h[1-6]', line.strip()))
+    return bool(re.match(r"<h[1-6]", line.strip()))
 
 
 def get_heading_text(line):
@@ -504,7 +563,7 @@ def find_html_match(lines, docx_norm, start_from=0, max_ahead=80):
     for i in range(start_from, end):
         line = lines[i].strip()
         # Only match against paragraph/list lines, not headings or structural elements
-        if not (line.startswith('<p ') or line.startswith('<li')):
+        if not (line.startswith("<p ") or line.startswith("<li")):
             continue
 
         html_norm = normalize(strip_html_tags(line))
@@ -550,6 +609,7 @@ def find_heading_match(lines, heading_norm, start_from=0, max_ahead=100):
 
 # ─── main processing ─────────────────────────────────────────────────
 
+
 def process_chapter(html_path, docx_paras, html_chapter_num, docx_chapter_num):
     """
     Process a single chapter HTML file using the docx paragraph sequence.
@@ -560,10 +620,10 @@ def process_chapter(html_path, docx_paras, html_chapter_num, docx_chapter_num):
     3. Insert display equations at correct positions
     4. Rebuild inline math paragraphs from docx fragments
     """
-    with open(html_path, 'r', encoding='utf-8') as f:
+    with open(html_path, "r", encoding="utf-8") as f:
         content = f.read()
 
-    lines = content.split('\n')
+    lines = content.split("\n")
 
     # Step 1: Remove all existing display-math lines
     removed_display = 0
@@ -578,23 +638,22 @@ def process_chapter(html_path, docx_paras, html_chapter_num, docx_chapter_num):
 
     # Find the chapter-content div boundaries
     content_start = 0
-    content_end = len(lines)
+    len(lines)
     for i, line in enumerate(lines):
         if 'class="chapter-content"' in line:
             content_start = i + 1
             break
     for i in range(len(lines) - 1, content_start, -1):
-        if '</div>' in lines[i] and i > content_start:
+        if "</div>" in lines[i] and i > content_start:
             # Look for the chapter-nav-bottom that marks end of content
             pass
         if 'class="chapter-nav-bottom"' in lines[i]:
-            content_end = i
             break
 
     # Step 2: Walk docx and HTML in tandem
     html_cursor = content_start  # current position in HTML lines
     insertions = []  # (line_index, html_to_insert)
-    rebuilds = {}    # line_index -> new_line_content
+    rebuilds = {}  # line_index -> new_line_content
     inline_count = 0
     display_count = 0
     skipped_display = 0
@@ -604,47 +663,56 @@ def process_chapter(html_path, docx_paras, html_chapter_num, docx_chapter_num):
         # Skip entries before the chapter title
         if di == 0:
             # First entry is the chapter heading itself; find it in HTML
-            heading_idx = find_heading_match(lines, entry['normalized'], content_start, 50)
+            heading_idx = find_heading_match(
+                lines, entry["normalized"], content_start, 50
+            )
             if heading_idx >= 0:
                 html_cursor = heading_idx + 1
             continue
 
-        if entry['is_display_only']:
+        if entry["is_display_only"]:
             # This is a standalone display equation - insert it at current position
-            if not entry.get('display_html'):
+            if not entry.get("display_html"):
                 skipped_display += 1
                 continue
 
-            eq_html = entry['display_html']
+            eq_html = entry["display_html"]
             eq_line = f'<p class="display-math"><em class="math">{eq_html}</em></p>'
 
             # Find the best insertion point: after the preceding text paragraph
             # Look backward in docx for the nearest non-display paragraph
             prev_text = None
             for pi in range(di - 1, max(0, di - 10), -1):
-                if not docx_paras[pi]['is_display_only'] and docx_paras[pi]['text']:
+                if not docx_paras[pi]["is_display_only"] and docx_paras[pi]["text"]:
                     prev_text = docx_paras[pi]
                     break
 
             # Also look forward for the next non-display paragraph
             next_text = None
             for ni in range(di + 1, min(len(docx_paras), di + 10)):
-                if not docx_paras[ni]['is_display_only'] and docx_paras[ni]['text']:
+                if not docx_paras[ni]["is_display_only"] and docx_paras[ni]["text"]:
                     next_text = docx_paras[ni]
                     break
 
             insert_after = -1
 
             if prev_text:
-                if prev_text['is_heading']:
+                if prev_text["is_heading"]:
                     # Preceding element is a heading
-                    h_idx = find_heading_match(lines, prev_text['normalized'], html_cursor - 5, 100)
+                    h_idx = find_heading_match(
+                        lines, prev_text["normalized"], html_cursor - 5, 100
+                    )
                     if h_idx >= 0:
                         insert_after = h_idx
                         html_cursor = max(html_cursor, h_idx + 1)
                 else:
                     # Preceding element is a text paragraph
-                    h_idx, score = find_html_match(lines, prev_text['norm_full'], max(content_start, html_cursor - 5), 100)
+                    h_idx, score = find_html_match(
+                        lines,
+                        prev_text["norm_full"],
+                        max(content_start, html_cursor - 5),
+                        100,
+                    )
                     if h_idx >= 0:
                         insert_after = h_idx
                         html_cursor = max(html_cursor, h_idx + 1)
@@ -652,12 +720,16 @@ def process_chapter(html_path, docx_paras, html_chapter_num, docx_chapter_num):
             if insert_after < 0:
                 # Couldn't find preceding paragraph; try next paragraph and insert before it
                 if next_text:
-                    if next_text['is_heading']:
-                        h_idx = find_heading_match(lines, next_text['normalized'], html_cursor, 100)
+                    if next_text["is_heading"]:
+                        h_idx = find_heading_match(
+                            lines, next_text["normalized"], html_cursor, 100
+                        )
                         if h_idx >= 0:
                             insert_after = h_idx - 1
                     else:
-                        h_idx, score = find_html_match(lines, next_text['norm_full'], html_cursor, 100)
+                        h_idx, score = find_html_match(
+                            lines, next_text["norm_full"], html_cursor, 100
+                        )
                         if h_idx >= 0:
                             insert_after = h_idx - 1
 
@@ -667,18 +739,24 @@ def process_chapter(html_path, docx_paras, html_chapter_num, docx_chapter_num):
             else:
                 skipped_display += 1
 
-        elif entry['is_heading']:
+        elif entry["is_heading"]:
             # Use headings as anchor points to keep cursors aligned
-            h_idx = find_heading_match(lines, entry['normalized'], max(content_start, html_cursor - 5), 150)
+            h_idx = find_heading_match(
+                lines, entry["normalized"], max(content_start, html_cursor - 5), 150
+            )
             if h_idx >= 0:
                 html_cursor = h_idx + 1
 
-        elif entry['has_math'] and entry['fragments'] and entry['text']:
+        elif entry["has_math"] and entry["fragments"] and entry["text"]:
             # Paragraph with inline math - find matching HTML and rebuild if needed
-            h_idx, score = find_html_match(lines, entry['norm_full'], max(content_start, html_cursor - 5), 100)
+            h_idx, score = find_html_match(
+                lines, entry["norm_full"], max(content_start, html_cursor - 5), 100
+            )
             if h_idx < 0:
                 # Also try matching against the text without math
-                h_idx, score = find_html_match(lines, entry['normalized'], max(content_start, html_cursor - 5), 100)
+                h_idx, score = find_html_match(
+                    lines, entry["normalized"], max(content_start, html_cursor - 5), 100
+                )
 
             if h_idx >= 0:
                 html_cursor = h_idx + 1
@@ -688,7 +766,9 @@ def process_chapter(html_path, docx_paras, html_chapter_num, docx_chapter_num):
                 needs_rebuild = False
 
                 # Count math elements in docx vs HTML
-                docx_math_count = sum(1 for f in entry['fragments'] if f[0] in ('math', 'displaymath'))
+                docx_math_count = sum(
+                    1 for f in entry["fragments"] if f[0] in ("math", "displaymath")
+                )
                 html_math_count = html_line.count('class="math"')
 
                 # Check 1: Line has no math but docx does
@@ -701,41 +781,46 @@ def process_chapter(html_path, docx_paras, html_chapter_num, docx_chapter_num):
 
                 # Check 3: Line has gaps (double spaces, "If ,", "and .")
                 text_only = strip_html_tags(html_line)
-                if '  ' in text_only:
+                if "  " in text_only:
                     needs_rebuild = True
-                if re.search(r'(?<=[A-Za-z])\s+[,.:;)]', text_only):
+                if re.search(r"(?<=[A-Za-z])\s+[,.:;)]", text_only):
                     needs_rebuild = True
-                if re.search(r'At\s*:', text_only) and 'class="math"' not in html_line:
+                if re.search(r"At\s*:", text_only) and 'class="math"' not in html_line:
                     needs_rebuild = True
 
                 # Check 4: Empty parentheses () suggesting stripped math
-                if re.search(r'\(\)', text_only):
+                if re.search(r"\(\)", text_only):
                     needs_rebuild = True
 
                 # Check 5: Comma-space after word with no preceding math: "component ,"
-                if re.search(r'\w\s+,', text_only) and docx_math_count > html_math_count:
+                if (
+                    re.search(r"\w\s+,", text_only)
+                    and docx_math_count > html_math_count
+                ):
                     needs_rebuild = True
 
                 if needs_rebuild:
                     # Extract the opening tag from the current HTML line
-                    tag_match = re.match(r'(<(?:p|li)[^>]*>)', html_line)
+                    tag_match = re.match(r"(<(?:p|li)[^>]*>)", html_line)
                     if tag_match:
                         open_tag = tag_match.group(1)
                         # Determine closing tag
-                        if open_tag.startswith('<li'):
-                            close_tag = '</li>'
+                        if open_tag.startswith("<li"):
+                            close_tag = "</li>"
                         else:
-                            close_tag = '</p>'
+                            close_tag = "</p>"
 
-                        rebuilt = rebuild_from_fragments(entry['fragments'])
+                        rebuilt = rebuild_from_fragments(entry["fragments"])
                         if rebuilt.strip():
-                            rebuilds[h_idx] = f'{open_tag}{rebuilt}{close_tag}'
+                            rebuilds[h_idx] = f"{open_tag}{rebuilt}{close_tag}"
                             inline_count += 1
 
         else:
             # Non-math paragraph - use for cursor tracking only
-            if entry['text'] and len(entry['normalized']) >= 15:
-                h_idx, score = find_html_match(lines, entry['normalized'], max(content_start, html_cursor - 3), 60)
+            if entry["text"] and len(entry["normalized"]) >= 15:
+                h_idx, score = find_html_match(
+                    lines, entry["normalized"], max(content_start, html_cursor - 3), 60
+                )
                 if h_idx >= 0 and score >= 70:
                     html_cursor = h_idx + 1
 
@@ -753,40 +838,40 @@ def process_chapter(html_path, docx_paras, html_chapter_num, docx_chapter_num):
     # Step 4: Post-process - clean up double spaces around math tags in all lines
     for i in range(len(lines)):
         line = lines[i]
-        if 'class="math"' in line and ('  ' in strip_html_tags(line)):
+        if 'class="math"' in line and ("  " in strip_html_tags(line)):
             # Clean double spaces between text and math tags
-            line = re.sub(r'\s+((<em class="math">))', r' \1', line)
-            line = re.sub(r'(</em>)\s+', r'\1 ', line)
+            line = re.sub(r'\s+((<em class="math">))', r" \1", line)
+            line = re.sub(r"(</em>)\s+", r"\1 ", line)
             # Clean double spaces within text
             # But be careful not to break HTML attributes
             # Only clean text segments (outside tags)
-            parts = re.split(r'(<[^>]+>)', line)
+            parts = re.split(r"(<[^>]+>)", line)
             cleaned_parts = []
             for part in parts:
-                if part.startswith('<'):
+                if part.startswith("<"):
                     cleaned_parts.append(part)
                 else:
-                    cleaned_parts.append(re.sub(r'  +', ' ', part))
-            lines[i] = ''.join(cleaned_parts)
+                    cleaned_parts.append(re.sub(r"  +", " ", part))
+            lines[i] = "".join(cleaned_parts)
 
     # Write back
-    with open(html_path, 'w', encoding='utf-8', newline='\n') as f:
-        f.write('\n'.join(lines))
+    with open(html_path, "w", encoding="utf-8", newline="\n") as f:
+        f.write("\n".join(lines))
 
     return {
-        'removed': removed_display,
-        'display_inserted': display_count,
-        'display_skipped': skipped_display,
-        'inline_rebuilt': inline_count,
+        "removed": removed_display,
+        "display_inserted": display_count,
+        "display_skipped": skipped_display,
+        "inline_rebuilt": inline_count,
     }
 
 
 def verify_chapter(html_path):
     """Verify a chapter HTML file for remaining issues."""
-    with open(html_path, 'r', encoding='utf-8') as f:
+    with open(html_path, "r", encoding="utf-8") as f:
         content = f.read()
 
-    lines = content.split('\n')
+    lines = content.split("\n")
     display_count = 0
     inline_count = 0
     remaining_gaps = 0
@@ -809,34 +894,35 @@ def verify_chapter(html_path):
         if not in_content:
             continue
 
-        if '<p ' in line or '<li' in line:
+        if "<p " in line or "<li" in line:
             text = strip_html_tags(line).strip()
-            if 'display-math' in line:
+            if "display-math" in line:
                 continue
             if not text:
                 continue
             # Check for real double-space gaps in content text
-            if '  ' in text:
+            if "  " in text:
                 remaining_gaps += 1
             # Check for "word ," / "word ." patterns suggesting missing inline math
-            if re.search(r'(?<=[A-Za-z])\s{2,}[,.:;)]', text):
+            if re.search(r"(?<=[A-Za-z])\s{2,}[,.:;)]", text):
                 remaining_patterns += 1
 
     return {
-        'display_math': display_count,
-        'inline_math': inline_count,
-        'remaining_gaps': remaining_gaps,
-        'remaining_patterns': remaining_patterns,
+        "display_math": display_count,
+        "inline_math": inline_count,
+        "remaining_gaps": remaining_gaps,
+        "remaining_patterns": remaining_patterns,
     }
 
 
 # ─── chapter file mapping ────────────────────────────────────────────
 
+
 def get_chapter_files():
     """Map HTML chapter numbers to filenames."""
     chapter_files = {}
     for fname in os.listdir(BOOK_DIR):
-        m = re.match(r'chapter-(\d+)-', fname)
+        m = re.match(r"chapter-(\d+)-", fname)
         if m:
             chapter_files[int(m.group(1))] = fname
     return chapter_files
@@ -847,6 +933,7 @@ def get_chapter_files():
 # Chapters 20-28: skip (generated separately)
 # Chapter 29 HTML = docx chapter 20
 # Chapter 30 HTML = docx chapter 21
+
 
 def html_to_docx_chapter(html_ch):
     """Map HTML chapter number to docx chapter number. Returns None for skip."""
@@ -862,6 +949,7 @@ def html_to_docx_chapter(html_ch):
 
 
 # ─── main ─────────────────────────────────────────────────────────────
+
 
 def main():
     print("=" * 70)
@@ -880,9 +968,9 @@ def main():
     total_inline_math = 0
     for ch_num, paras in docx_chapters.items():
         for p in paras:
-            if p['is_display_only']:
+            if p["is_display_only"]:
                 total_display += 1
-            if p['has_math'] and not p['is_display_only']:
+            if p["has_math"] and not p["is_display_only"]:
                 total_inline_math += 1
     print(f"  {total_display} display equation paragraphs")
     print(f"  {total_inline_math} paragraphs with inline math")
@@ -891,10 +979,10 @@ def main():
     chapter_files = get_chapter_files()
 
     total_stats = {
-        'display_inserted': 0,
-        'inline_rebuilt': 0,
-        'display_skipped': 0,
-        'removed': 0,
+        "display_inserted": 0,
+        "inline_rebuilt": 0,
+        "display_skipped": 0,
+        "removed": 0,
     }
 
     # Process each chapter
@@ -903,7 +991,9 @@ def main():
         if docx_ch is None:
             continue
         if docx_ch not in docx_chapters:
-            print(f"  WARNING: docx chapter {docx_ch} not found for HTML chapter {html_ch}")
+            print(
+                f"  WARNING: docx chapter {docx_ch} not found for HTML chapter {html_ch}"
+            )
             continue
 
         fname = chapter_files[html_ch]
@@ -912,9 +1002,13 @@ def main():
 
         print(f"Processing Chapter {html_ch} (docx ch {docx_ch}): {fname}")
         stats = process_chapter(filepath, docx_paras, html_ch, docx_ch)
-        print(f"  Removed {stats['removed']} old display-math, inserted {stats['display_inserted']} new, rebuilt {stats['inline_rebuilt']} inline")
-        if stats['display_skipped'] > 0:
-            print(f"  ({stats['display_skipped']} display equations could not be placed)")
+        print(
+            f"  Removed {stats['removed']} old display-math, inserted {stats['display_inserted']} new, rebuilt {stats['inline_rebuilt']} inline"
+        )
+        if stats["display_skipped"] > 0:
+            print(
+                f"  ({stats['display_skipped']} display equations could not be placed)"
+            )
 
         for k in total_stats:
             total_stats[k] += stats[k]
@@ -941,33 +1035,41 @@ def main():
         filepath = os.path.join(BOOK_DIR, fname)
         v = verify_chapter(filepath)
 
-        print(f"Ch {html_ch:<8} {v['display_math']:>8} {v['inline_math']:>8} {v['remaining_gaps']:>8} {v['remaining_patterns']:>10}")
-        grand_display += v['display_math']
-        grand_inline += v['inline_math']
-        grand_gaps += v['remaining_gaps']
-        grand_patterns += v['remaining_patterns']
+        print(
+            f"Ch {html_ch:<8} {v['display_math']:>8} {v['inline_math']:>8} {v['remaining_gaps']:>8} {v['remaining_patterns']:>10}"
+        )
+        grand_display += v["display_math"]
+        grand_inline += v["inline_math"]
+        grand_gaps += v["remaining_gaps"]
+        grand_patterns += v["remaining_patterns"]
 
     print("-" * 50)
-    print(f"{'TOTAL':<12} {grand_display:>8} {grand_inline:>8} {grand_gaps:>8} {grand_patterns:>10}")
+    print(
+        f"{'TOTAL':<12} {grand_display:>8} {grand_inline:>8} {grand_gaps:>8} {grand_patterns:>10}"
+    )
     print()
-    print(f"Summary: {total_stats['removed']} old display-math removed, "
-          f"{total_stats['display_inserted']} new display equations inserted, "
-          f"{total_stats['inline_rebuilt']} inline math paragraphs rebuilt")
-    print(f"         {total_stats['display_skipped']} display equations could not be placed")
+    print(
+        f"Summary: {total_stats['removed']} old display-math removed, "
+        f"{total_stats['display_inserted']} new display equations inserted, "
+        f"{total_stats['inline_rebuilt']} inline math paragraphs rebuilt"
+    )
+    print(
+        f"         {total_stats['display_skipped']} display equations could not be placed"
+    )
     print()
 
     # Ensure CSS is present
-    css_path = os.path.join(BOOK_DIR, 'book.css')
-    with open(css_path, 'r', encoding='utf-8') as f:
+    css_path = os.path.join(BOOK_DIR, "book.css")
+    with open(css_path, "r", encoding="utf-8") as f:
         css = f.read()
-    if '.display-math' not in css:
+    if ".display-math" not in css:
         css += '\n\n/* Display equations */\np.display-math { text-align: center; margin: 1.2em 0; font-size: 1.1em; }\np.display-math em.math { font-style: italic; font-family: "Cambria Math", "STIX Two Math", serif; }\n'
-        with open(css_path, 'w', encoding='utf-8') as f:
+        with open(css_path, "w", encoding="utf-8") as f:
             f.write(css)
         print("Added .display-math CSS to book.css")
 
     print("Done.")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/fix_unclosed_em.py
+++ b/fix_unclosed_em.py
@@ -3,11 +3,13 @@
 The pattern: <em class="math">\gamma_i* should be <em class="math">\gamma_i^*</em>
 The * gets eaten by markdown as italic start/end, leaving unclosed tags.
 """
+
 import os
 import re
 
+
 def fix_file(path):
-    with open(path, 'r', encoding='utf-8') as f:
+    with open(path, "r", encoding="utf-8") as f:
         content = f.read()
 
     original = content
@@ -16,8 +18,12 @@ def fix_file(path):
     # Replace with proper closing
     content = re.sub(
         r'(<em class="math">)(.*?)\*\.\s*(?:The|A|Each|This|In|For|When|Where|If|Since|Let|Given|Note)',
-        lambda m: m.group(1) + m.group(2) + '^*</em>. ' + m.group(0).split('. ', 1)[1] if '. ' in m.group(0) else m.group(0),
-        content
+        lambda m: (
+            m.group(1) + m.group(2) + "^*</em>. " + m.group(0).split(". ", 1)[1]
+            if ". " in m.group(0)
+            else m.group(0)
+        ),
+        content,
     )
 
     # More targeted: find <em class="math"> without matching </em> before next tag
@@ -27,29 +33,33 @@ def fix_file(path):
         fixed_parts = [parts[0]]
         for part in parts[1:]:
             # Check if </em> comes before the next < tag (excluding </em> itself)
-            em_close = part.find('</em>')
-            next_tag = re.search(r'<(?!/)(?!em)', part)
+            em_close = part.find("</em>")
+            next_tag = re.search(r"<(?!/)(?!em)", part)
 
             if em_close == -1:
                 # No closing tag at all - find a reasonable place to close
                 # Look for end of math content (period, comma, space followed by word)
-                match = re.search(r'([^<]*?)(\.\s|\,\s|\s(?=[A-Z]))', part)
+                match = re.search(r"([^<]*?)(\.\s|\,\s|\s(?=[A-Z]))", part)
                 if match:
                     math_content = match.group(1)
                     # Clean up the math content - replace trailing * with ^*
-                    if math_content.endswith('*'):
-                        math_content = math_content[:-1] + '^*'
-                    fixed_parts.append(math_content + '</em>' + part[match.end()-len(match.group(2)):])
+                    if math_content.endswith("*"):
+                        math_content = math_content[:-1] + "^*"
+                    fixed_parts.append(
+                        math_content
+                        + "</em>"
+                        + part[match.end() - len(match.group(2)) :]
+                    )
                 else:
                     fixed_parts.append(part)  # can't fix safely
             elif next_tag and next_tag.start() < em_close:
                 # Closing tag comes after another HTML tag - might be unclosed
                 # Check if there's meaningful math content before the next tag
-                pre_tag = part[:next_tag.start()]
-                if '*' in pre_tag and '</em>' not in pre_tag:
+                pre_tag = part[: next_tag.start()]
+                if "*" in pre_tag and "</em>" not in pre_tag:
                     # Fix: close before the *, treat * as ^*
-                    pre_tag = pre_tag.replace('*', '^*</em>', 1)
-                    fixed_parts.append(pre_tag + part[next_tag.start():])
+                    pre_tag = pre_tag.replace("*", "^*</em>", 1)
+                    fixed_parts.append(pre_tag + part[next_tag.start() :])
                 else:
                     fixed_parts.append(part)
             else:
@@ -58,22 +68,30 @@ def fix_file(path):
         content = '<em class="math">'.join(fixed_parts)
 
     if content != original:
-        with open(path, 'w', encoding='utf-8') as f:
+        with open(path, "w", encoding="utf-8") as f:
             f.write(content)
         return True
     return False
 
+
 count = 0
-for book in ['book', 'geometric-reasoning', 'geometric-economics', 'geometric-law',
-             'geometric-cognition', 'geometric-communication', 'geometric-medicine']:
-    book_dir = os.path.join('docs', book)
+for book in [
+    "book",
+    "geometric-reasoning",
+    "geometric-economics",
+    "geometric-law",
+    "geometric-cognition",
+    "geometric-communication",
+    "geometric-medicine",
+]:
+    book_dir = os.path.join("docs", book)
     if not os.path.isdir(book_dir):
         continue
     for fn in sorted(os.listdir(book_dir)):
-        if not fn.endswith('.html') or fn == 'index.html':
+        if not fn.endswith(".html") or fn == "index.html":
             continue
         if fix_file(os.path.join(book_dir, fn)):
             count += 1
-            print(f'  Fixed: {book}/{fn}')
+            print(f"  Fixed: {book}/{fn}")
 
-print(f'\nTotal: {count} files fixed')
+print(f"\nTotal: {count} files fixed")

--- a/test_website.py
+++ b/test_website.py
@@ -1,9 +1,12 @@
 """Selenium test for Geometric Ethics website interactivity."""
+
 import os
-import time
 import sys
+import time
+
 from selenium import webdriver
 from selenium.webdriver.common.by import By
+
 
 def test_website():
     html_path = os.path.abspath("docs/index.html")
@@ -26,11 +29,15 @@ def test_website():
         print(f"  [{status}] {name}" + (f" - {detail}" if detail else ""))
 
     def click(el):
-        driver.execute_script("arguments[0].scrollIntoView({block:'center'}); arguments[0].click();", el)
+        driver.execute_script(
+            "arguments[0].scrollIntoView({block:'center'}); arguments[0].click();", el
+        )
         time.sleep(0.4)
 
     def css(el, prop):
-        return driver.execute_script(f"return getComputedStyle(arguments[0]).{prop}", el)
+        return driver.execute_script(
+            f"return getComputedStyle(arguments[0]).{prop}", el
+        )
 
     print("\n=== Geometric Ethics Website Interactive Test ===\n")
 
@@ -38,38 +45,57 @@ def test_website():
     print("--- Basic ---")
     check("Page title", "Geometric Ethics" in driver.title)
     check("Nav exists", len(driver.find_elements(By.CSS_SELECTOR, "#main-nav")) > 0)
-    check("Hero particles", len(driver.find_elements(By.CSS_SELECTOR, "#hero canvas")) > 0)
+    check(
+        "Hero particles", len(driver.find_elements(By.CSS_SELECTOR, "#hero canvas")) > 0
+    )
 
     # 2. Parable timeline
     print("\n--- Parable Timeline ---")
     events = driver.find_elements(By.CSS_SELECTOR, ".timeline-event")
     check("4 timeline events", len(events) == 4)
-    check("One is active", len(driver.find_elements(By.CSS_SELECTOR, ".timeline-event.active")) == 1)
+    check(
+        "One is active",
+        len(driver.find_elements(By.CSS_SELECTOR, ".timeline-event.active")) == 1,
+    )
 
     # 3. Object cards
     print("\n--- Object Cards ---")
     cards = driver.find_elements(By.CSS_SELECTOR, ".object-card")
     check("8 object cards", len(cards) == 8)
     click(cards[0])
-    check("Expands on click", len(driver.find_elements(By.CSS_SELECTOR, ".object-card.expanded")) > 0)
+    check(
+        "Expands on click",
+        len(driver.find_elements(By.CSS_SELECTOR, ".object-card.expanded")) > 0,
+    )
     formal = cards[0].find_elements(By.CSS_SELECTOR, ".object-formal")
     if formal:
         check("Formal def visible", css(formal[0], "opacity") == "1")
 
     # 4. Dimension wheel
     print("\n--- Dimension Wheel ---")
-    check("9 dimension dots", len(driver.find_elements(By.CSS_SELECTOR, "#dim-lines circle")) == 9)
-    check("9 labels", len(driver.find_elements(By.CSS_SELECTOR, "#dim-labels text")) == 9)
+    check(
+        "9 dimension dots",
+        len(driver.find_elements(By.CSS_SELECTOR, "#dim-lines circle")) == 9,
+    )
+    check(
+        "9 labels", len(driver.find_elements(By.CSS_SELECTOR, "#dim-labels text")) == 9
+    )
     dim_cards = driver.find_elements(By.CSS_SELECTOR, ".dim-card")
     click(dim_cards[2])
-    check("Dim card activates", len(driver.find_elements(By.CSS_SELECTOR, ".dim-card.active")) == 1)
+    check(
+        "Dim card activates",
+        len(driver.find_elements(By.CSS_SELECTOR, ".dim-card.active")) == 1,
+    )
 
     # 5. Tensor hierarchy
     print("\n--- Tensor Hierarchy ---")
     btns = driver.find_elements(By.CSS_SELECTOR, ".level-btn")
     check("6+ level buttons", len(btns) >= 6)
     click(btns[2])
-    check("Button activates", len(driver.find_elements(By.CSS_SELECTOR, ".level-btn.active")) == 1)
+    check(
+        "Button activates",
+        len(driver.find_elements(By.CSS_SELECTOR, ".level-btn.active")) == 1,
+    )
     lv2 = driver.find_elements(By.CSS_SELECTOR, "#h-level-2")
     if lv2:
         check("Level 2 shown", css(lv2[0], "display") != "none")
@@ -79,19 +105,30 @@ def test_website():
     headers = driver.find_elements(By.CSS_SELECTOR, ".part-header")
     check("7 parts", len(headers) == 7)
     click(headers[0])
-    check("Part opens", len(driver.find_elements(By.CSS_SELECTOR, ".part-item.open")) == 1)
+    check(
+        "Part opens", len(driver.find_elements(By.CSS_SELECTOR, ".part-item.open")) == 1
+    )
 
     # 7. Theorem cards
     print("\n--- Theorem Cards ---")
     thms = driver.find_elements(By.CSS_SELECTOR, ".theorem-card")
     check("7 theorem cards", len(thms) == 7)
     click(thms[0])
-    check("Expands on click", len(driver.find_elements(By.CSS_SELECTOR, ".theorem-card.expanded")) > 0)
+    check(
+        "Expands on click",
+        len(driver.find_elements(By.CSS_SELECTOR, ".theorem-card.expanded")) > 0,
+    )
     detail = thms[0].find_elements(By.CSS_SELECTOR, ".theorem-detail")
     if detail:
         check("Detail visible", css(detail[0], "opacity") == "1")
-        check("Detail has content", len(detail[0].text) > 20, f"{len(detail[0].text)} chars")
-    check("Hint exists", len(thms[0].find_elements(By.CSS_SELECTOR, ".theorem-hint")) > 0)
+        check(
+            "Detail has content",
+            len(detail[0].text) > 20,
+            f"{len(detail[0].text)} chars",
+        )
+    check(
+        "Hint exists", len(thms[0].find_elements(By.CSS_SELECTOR, ".theorem-hint")) > 0
+    )
 
     # 8. Application hex cards *** FOCUS ***
     print("\n--- App Hex Cards (VII) ***FOCUS*** ---")
@@ -103,7 +140,10 @@ def test_website():
         check(f"  '{name}' pointer cursor", css(h, "cursor") == "pointer")
 
     click(hexes[0])
-    check("Hex activates", len(driver.find_elements(By.CSS_SELECTOR, ".app-hex.active")) > 0)
+    check(
+        "Hex activates",
+        len(driver.find_elements(By.CSS_SELECTOR, ".app-hex.active")) > 0,
+    )
     panels = driver.find_elements(By.CSS_SELECTOR, ".app-detail-panel")
     check("Detail panel created", len(panels) > 0)
     if panels:
@@ -112,10 +152,15 @@ def test_website():
 
     click(hexes[3])
     active = driver.find_elements(By.CSS_SELECTOR, ".app-hex.active")
-    check("Switch to finance", len(active) == 1 and active[0].get_attribute("data-app") == "finance")
+    check(
+        "Switch to finance",
+        len(active) == 1 and active[0].get_attribute("data-app") == "finance",
+    )
 
     click(hexes[3])
-    check("Deactivate", len(driver.find_elements(By.CSS_SELECTOR, ".app-hex.active")) == 0)
+    check(
+        "Deactivate", len(driver.find_elements(By.CSS_SELECTOR, ".app-hex.active")) == 0
+    )
 
     # 9. Equation
     print("\n--- Equation ---")
@@ -129,7 +174,10 @@ def test_website():
     check("4 consequences", len(cons) == 4)
     check("Clickable cursor", css(cons[0], "cursor") == "pointer")
     click(cons[0])
-    check("Activates", len(driver.find_elements(By.CSS_SELECTOR, ".consequence.active")) == 1)
+    check(
+        "Activates",
+        len(driver.find_elements(By.CSS_SELECTOR, ".consequence.active")) == 1,
+    )
 
     # 11. Reading paths
     print("\n--- Reading Paths ---")
@@ -139,7 +187,10 @@ def test_website():
 
     # 12. DEME architecture
     print("\n--- DEME Architecture ---")
-    check("Tooltip created", len(driver.find_elements(By.CSS_SELECTOR, ".deme-tooltip")) > 0)
+    check(
+        "Tooltip created",
+        len(driver.find_elements(By.CSS_SELECTOR, ".deme-tooltip")) > 0,
+    )
     rects = driver.find_elements(By.CSS_SELECTOR, ".deme-svg rect")
     check(f"{len(rects)} SVG rects", len(rects) >= 7)
 
@@ -149,7 +200,10 @@ def test_website():
     check("4 epistemic cards", len(eps) == 4)
     click(eps[0])
     time.sleep(0.5)
-    check("Expands", len(driver.find_elements(By.CSS_SELECTOR, ".epistemic-card.expanded")) > 0)
+    check(
+        "Expands",
+        len(driver.find_elements(By.CSS_SELECTOR, ".epistemic-card.expanded")) > 0,
+    )
     ep_d = eps[0].find_elements(By.CSS_SELECTOR, ".epistemic-detail")
     if ep_d:
         check("Detail visible", css(ep_d[0], "opacity") == "1")
@@ -159,12 +213,15 @@ def test_website():
     btns = driver.find_elements(By.CSS_SELECTOR, ".game-choices .choice-btn")
     check("8 choice buttons", len(btns) == 8)
     click(btns[0])  # O for neighbor
-    check("Button activates", len(driver.find_elements(By.CSS_SELECTOR, ".choice-btn.active-choice")) >= 1)
+    check(
+        "Button activates",
+        len(driver.find_elements(By.CSS_SELECTOR, ".choice-btn.active-choice")) >= 1,
+    )
     click(btns[5])  # C for writer
     result = driver.find_elements(By.CSS_SELECTOR, ".game-result")
     if result:
         check("Result appears", css(result[0], "display") != "none")
-        rt = result[0].text.encode('ascii', 'replace').decode()
+        rt = result[0].text.encode("ascii", "replace").decode()
         check("Result has text", len(result[0].text) > 10, rt[:60])
 
     # 15. Bell test slider
@@ -188,11 +245,17 @@ def test_website():
     check(f"{len(tags)} concept tags", len(tags) > 0)
     click(tags[0])
     time.sleep(0.5)
-    modal_overlay = driver.find_elements(By.CSS_SELECTOR, ".concept-modal-overlay.visible")
+    modal_overlay = driver.find_elements(
+        By.CSS_SELECTOR, ".concept-modal-overlay.visible"
+    )
     check("Modal opens", len(modal_overlay) > 0)
     if modal_overlay:
         title = driver.find_elements(By.CSS_SELECTOR, ".concept-modal-title")
-        check("Modal has title", len(title) > 0 and len(title[0].text) > 0, title[0].text if title else "")
+        check(
+            "Modal has title",
+            len(title) > 0 and len(title[0].text) > 0,
+            title[0].text if title else "",
+        )
         formal = driver.find_elements(By.CSS_SELECTOR, ".concept-formal")
         check("Modal has formal def", len(formal) > 0 and len(formal[0].text) > 20)
         desc = driver.find_elements(By.CSS_SELECTOR, ".concept-modal-desc")
@@ -204,7 +267,15 @@ def test_website():
         if close_btn:
             click(close_btn[0])
             time.sleep(0.3)
-            check("Modal closes", len(driver.find_elements(By.CSS_SELECTOR, ".concept-modal-overlay.visible")) == 0)
+            check(
+                "Modal closes",
+                len(
+                    driver.find_elements(
+                        By.CSS_SELECTOR, ".concept-modal-overlay.visible"
+                    )
+                )
+                == 0,
+            )
 
     # 17. Visual demos
     print("\n--- Visual Demos ---")
@@ -231,6 +302,7 @@ def test_website():
 
     driver.quit()
     return failed == 0
+
 
 if __name__ == "__main__":
     success = test_website()


### PR DESCRIPTION
Here is a simple, one-paragraph description you can use:

This PR applies standard formatting and linting fixes to the 13 newly updated root Python scripts responsible for HTML and math rendering (such as fix_math.py). Specifically, all files were reformatted using `black` to ensure consistent indentation and line lengths, while `ruff` was used to clean up unnecessary code by removing unused library imports and unused local variables. Additionally, minor syntactical issues were resolved, such as suppressing unavoidable module-order warnings, resulting in perfectly clean code that passes all linting checks with zero errors.