### PR TITLE
Consume erisml-compiler Maxim/polarity in DEME (deontic gate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,59 @@ democratically-governed ethical reasoning, grounded in the **Philosophy Engineer
 
 | Repository | Description |
 |------------|-------------|
+| [ahb-sjsu/erisml-compiler](https://github.com/ahb-sjsu/erisml-compiler) | Natural-language → moral-IR **compiler** that feeds this library (see below) |
 | [ahb-sjsu/non-abelian-sqnd](https://github.com/ahb-sjsu/non-abelian-sqnd) | NA-SQND theoretical research - papers, experiments, and mathematical foundations |
 | [ahb-sjsu/sqnd-probe](https://github.com/ahb-sjsu/sqnd-probe) | Dear Ethicist - advice column game for measuring moral reasoning structure |
+
+---
+
+## Compiler integration (erisml-compiler → erisml-lib)
+
+[**erisml-compiler**](https://github.com/ahb-sjsu/erisml-compiler) is the
+*extraction* front-end; **erisml-lib** is the *evaluation* engine. The dataflow
+is one-way:
+
+```
+natural-language text
+  │  erisml-compiler:  spaCy SRL maxim extractor, projections (deontic/virtue/care)
+  ▼
+MoralSubstrate  ──►  Maxim(action_kind, polarity)  +  V3 EthicalFacts (9-dim)
+  │  erisml-compiler/erisml_backend/v3_bridge.py
+  ▼
+erisml-lib:  DEME modules, MoralTensor aggregation, deontic maxim gate, I-EIP probes
+  ▼
+DecisionResult / EthicalJudgement
+```
+
+### Deontic maxim gate (polarity-aware)
+
+The compiler now extracts a `Maxim` including **polarity** — whether an action
+is asserted or negated ("did not promise", "refused to lie"). The library
+consumes this in `ethics/deontic_gate.py` and applies a Kantian
+universalizability veto inside `DEMEPipeline`'s reflex layer:
+
+```python
+from erisml.ethics.facts import EthicalFacts, Maxim
+from erisml.ethics.layers.pipeline import DEMEPipeline
+
+opt = EthicalFacts(option_id="o1", maxim=Maxim(action_kind="deceive"))
+result = DEMEPipeline().decide([opt])
+assert "o1" in result.forbidden_options          # deceiving fails universalizability
+```
+
+Polarity follows Kant's perfect/imperfect duty distinction:
+
+| maxim | polarity | gate |
+|---|---|---|
+| `deceive`, `inflict_harm`, `coerce`, … (prohibitions) | affirmed | **veto** |
+| `deceive` … (prohibitions) | negated ("did not deceive") | pass |
+| `help`, `protect` (imperfect duties) | affirmed | pass |
+| `help`, `protect` | negated ("did not help") | **veto** (contradiction in will) |
+| `make_or_keep_commitment`, `disclose` (permissible) | either | pass |
+| unknown action | either | pass (conservative) |
+
+The `EthicalFacts.maxim` field is optional and defaults to `None`, so existing
+callers are unaffected. `DEME.evaluate(maxim)` exposes the gate directly.
 
 ---
 

--- a/src/erisml/ethics/decision_proof.py
+++ b/src/erisml/ethics/decision_proof.py
@@ -319,9 +319,11 @@ def hash_ethical_facts(facts: Any) -> str:
         Hexadecimal hash string.
     """
     # Import here to avoid circular import
-    from dataclasses import asdict
+    from dataclasses import asdict, is_dataclass
 
-    data = asdict(facts)
+    # Accept dataclass instances, plain dicts, and lists alike: decide() hashes
+    # a {"options": [...]} summary dict, not only EthicalFacts dataclasses.
+    data = asdict(facts) if is_dataclass(facts) else facts
     canonical = json.dumps(data, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 

--- a/src/erisml/ethics/deme.py
+++ b/src/erisml/ethics/deme.py
@@ -22,7 +22,26 @@ class DEME:
         self.profile_path = profile_path
 
     def evaluate(self, context: Any) -> EthicalJudgement:
+        """Evaluate a context.
+
+        If the context carries a maxim (an ``EthicalFacts`` with a ``.maxim``,
+        or a ``Maxim`` directly), the deontic universalizability gate is applied
+        and a failing maxim yields a FORBID verdict. Otherwise ALLOW (the
+        full tensor/module pipeline lives in ``layers.pipeline.DEMEPipeline``).
         """
-        Placeholder evaluation logic to satisfy the API.
-        """
+        from erisml.ethics.deontic_gate import evaluate_maxim
+        from erisml.ethics.facts import Maxim
+
+        maxim = context if isinstance(context, Maxim) else getattr(context, "maxim", None)
+        gate = evaluate_maxim(maxim)
+        if gate.vetoed:
+            return EthicalJudgement(
+                verdict="FORBID",
+                confidence=0.9,
+                metadata={
+                    "deontic_gate": gate.reason,
+                    "contradiction_type": gate.contradiction_type,
+                    "action_kind": gate.action_kind,
+                },
+            )
         return EthicalJudgement(verdict="ALLOW", confidence=1.0, metadata={})

--- a/src/erisml/ethics/deontic_gate.py
+++ b/src/erisml/ethics/deontic_gate.py
@@ -1,0 +1,120 @@
+"""Deontic maxim gate for DEME — Kantian universalizability with polarity.
+
+This is the evaluation-engine side of the maxim semantics that erisml-compiler
+extracts. The compiler parses a ``Maxim`` (action_kind + polarity) from text;
+DEME applies the categorical-imperative universalizability test here, as a veto
+check in the pipeline's reflex layer.
+
+Polarity matters: a negated maxim ("did not promise", "refused to lie") is the
+maxim of *not performing* the action. Grounded in Kant's perfect/imperfect duty
+distinction:
+
+  * negating a prohibition (deceive, harm, coerce, cheat, ...) -> universalisable
+  * negating a merely-permissible act (make_or_keep_commitment, disclose) -> ok
+  * negating an imperfect duty (help, protect) -> fails contradiction-in-will
+  * unknown action -> undetermined (no veto)
+
+The action-kind classifications mirror erisml-compiler's
+``delta/universalizability.py`` knowledge base. They are duplicated here
+deliberately: the lib must be able to gate maxims without a hard dependency on
+the compiler (the dependency direction is compiler -> lib).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .facts import Maxim
+
+# Action kinds whose *affirmed* maxim fails universalizability.
+PROHIBITIONS: frozenset[str] = frozenset(
+    {
+        "deceive",
+        "break_commitment",
+        "cheat",
+        "impose_externality",
+        "coerce",
+        "coerce_or_be_coerced",
+        "inflict_harm",
+        "use_as_means",
+        "refuse",
+    }
+)
+# Positive (imperfect) duties: only these fail when *negated* (omission).
+IMPERFECT_DUTIES: frozenset[str] = frozenset({"help", "protect"})
+# Affirmed maxims that are universalisable (permissible or dutiful).
+PERMISSIBLE: frozenset[str] = frozenset(
+    {
+        "make_or_keep_commitment",
+        "protect",
+        "help",
+        "disclose",
+        "act_under_norm",
+        "act_under_authority",
+    }
+)
+
+
+@dataclass(frozen=True)
+class MaximGateResult:
+    """Outcome of the deontic gate for a single maxim."""
+
+    passes: bool
+    """True iff the (possibly negated) maxim is universalisable."""
+    vetoed: bool
+    """True iff DEME should veto the option on deontic grounds."""
+    reason: str
+    contradiction_type: str  # contradiction_in_conception | _in_will | no_contradiction | undetermined
+    action_kind: str | None
+
+
+def evaluate_maxim(maxim: Maxim | None) -> MaximGateResult:
+    """Apply the universalizability test to a maxim, honouring polarity.
+
+    A maxim that fails universalizability yields ``vetoed=True``. Unknown or
+    absent action kinds never veto (the gate is conservative).
+    """
+    if maxim is None or maxim.action_kind is None:
+        return MaximGateResult(
+            passes=True, vetoed=False, reason="No maxim to test.",
+            contradiction_type="undetermined", action_kind=None,
+        )
+
+    kind = maxim.action_kind
+    negated = maxim.polarity == "negated"
+    known = kind in PROHIBITIONS or kind in PERMISSIBLE or kind in IMPERFECT_DUTIES
+
+    if not known:
+        return MaximGateResult(
+            passes=True, vetoed=False,
+            reason=f"action_kind {kind!r} not in the universalizability KB; cannot test.",
+            contradiction_type="undetermined", action_kind=kind,
+        )
+
+    if not negated:
+        if kind in PROHIBITIONS:
+            return MaximGateResult(
+                passes=False, vetoed=True,
+                reason=f"Maxim of {kind!r} is not universalisable (categorical-imperative failure).",
+                contradiction_type="contradiction_in_conception", action_kind=kind,
+            )
+        return MaximGateResult(
+            passes=True, vetoed=False,
+            reason=f"Maxim of {kind!r} is universalisable.",
+            contradiction_type="no_contradiction", action_kind=kind,
+        )
+
+    # Negated maxim: the maxim of NOT performing the action.
+    if kind in IMPERFECT_DUTIES:
+        return MaximGateResult(
+            passes=False, vetoed=True,
+            reason=(
+                f"Refraining from {kind!r} omits an imperfect duty; universal "
+                f"omission cannot be willed (contradiction in will)."
+            ),
+            contradiction_type="contradiction_in_will", action_kind=f"not:{kind}",
+        )
+    return MaximGateResult(
+        passes=True, vetoed=False,
+        reason=f"Not performing {kind!r} is universalisable (refraining from a prohibited or permissible act).",
+        contradiction_type="no_contradiction", action_kind=f"not:{kind}",
+    )

--- a/src/erisml/ethics/facts.py
+++ b/src/erisml/ethics/facts.py
@@ -149,6 +149,21 @@ class ProceduralAndLegitimacy:
 
 
 @dataclass
+class Maxim:
+    """Kantian action-under-a-description, mirrored from erisml-compiler.
+
+    Carries the maxim semantics the compiler now extracts (incl. negation) so
+    DEME can apply the deontic universalizability gate. ``polarity`` is
+    "affirmed" or "negated" — a negated maxim ("did not promise") is the maxim
+    of *not performing* the action and is gated accordingly.
+    """
+
+    action_kind: Optional[str] = None
+    polarity: str = "affirmed"
+    description: str = ""
+
+
+@dataclass
 class EthicalFacts:
     option_id: str
     scenario_id: str = "default"
@@ -165,5 +180,6 @@ class EthicalFacts:
     privacy_and_data: Optional[PrivacyAndDataGovernance] = None
     societal_and_environmental: Optional[SocietalAndEnvironmental] = None
     procedural_and_legitimacy: Optional[ProceduralAndLegitimacy] = None
+    maxim: Optional[Maxim] = None
     tags: List[str] = field(default_factory=list)
     extra: Dict[str, Any] = field(default_factory=dict)

--- a/src/erisml/ethics/layers/pipeline.py
+++ b/src/erisml/ethics/layers/pipeline.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from erisml.ethics.modules.base import EthicsModuleV2
 
 from erisml.ethics.facts import EthicalFacts
+from erisml.ethics.deontic_gate import evaluate_maxim
 from erisml.ethics.moral_landscape import MoralLandscape
 from erisml.ethics.decision_proof import (
     DecisionProof,
@@ -147,11 +148,19 @@ class DEMEPipeline:
         reflex_start = time.perf_counter()
         reflex_results: Dict[str, VetoResult] = {}
         reflex_vetoed: List[str] = []
+        deontic_vetoes: Dict[str, str] = {}
 
         for facts in options:
             reflex_result = self.reflex.check(facts)
             reflex_results[facts.option_id] = reflex_result
-            if reflex_result.vetoed:
+            vetoed = reflex_result.vetoed
+            # Deontic maxim gate: veto options whose (possibly negated) maxim
+            # fails Kantian universalizability. No-op when no maxim is present.
+            maxim_result = evaluate_maxim(getattr(facts, "maxim", None))
+            if maxim_result.vetoed:
+                vetoed = True
+                deontic_vetoes[facts.option_id] = maxim_result.reason
+            if vetoed:
                 reflex_vetoed.append(facts.option_id)
 
         reflex_duration = int((time.perf_counter() - reflex_start) * 1_000_000)
@@ -166,6 +175,7 @@ class DEMEPipeline:
                 ),
                 output_data={
                     "vetoed_options": reflex_vetoed,
+                    "deontic_vetoes": deontic_vetoes,
                     "total_checked": len(options),
                 },
             )

--- a/tests/test_deontic_gate.py
+++ b/tests/test_deontic_gate.py
@@ -1,0 +1,68 @@
+"""Tests for the deontic maxim gate (Kantian universalizability with polarity)."""
+from __future__ import annotations
+
+from erisml.ethics.deme import DEME
+from erisml.ethics.deontic_gate import evaluate_maxim
+from erisml.ethics.facts import EthicalFacts, Maxim
+from erisml.ethics.layers.pipeline import DEMEPipeline
+
+
+# ----------------------------------------------------- gate logic
+
+
+def test_affirmed_prohibition_vetoes():
+    r = evaluate_maxim(Maxim(action_kind="deceive"))
+    assert r.vetoed is True
+    assert r.passes is False
+
+
+def test_negated_prohibition_passes():
+    r = evaluate_maxim(Maxim(action_kind="deceive", polarity="negated"))
+    assert r.vetoed is False
+    assert r.action_kind == "not:deceive"
+
+
+def test_affirmed_imperfect_duty_passes():
+    assert evaluate_maxim(Maxim(action_kind="help")).vetoed is False
+
+
+def test_negated_imperfect_duty_vetoes():
+    r = evaluate_maxim(Maxim(action_kind="help", polarity="negated"))
+    assert r.vetoed is True
+    assert r.contradiction_type == "contradiction_in_will"
+
+
+def test_negated_permissible_act_passes():
+    # Not making a promise is permissible — no veto.
+    r = evaluate_maxim(Maxim(action_kind="make_or_keep_commitment", polarity="negated"))
+    assert r.vetoed is False
+
+
+def test_unknown_and_missing_never_veto():
+    assert evaluate_maxim(Maxim(action_kind="mystery")).vetoed is False
+    assert evaluate_maxim(None).vetoed is False
+    assert evaluate_maxim(Maxim(action_kind=None)).vetoed is False
+
+
+# ----------------------------------------------------- DEME public API
+
+
+def test_deme_evaluate_forbids_failing_maxim():
+    j = DEME().evaluate(Maxim(action_kind="deceive"))
+    assert j.verdict == "FORBID"
+    assert "deontic_gate" in j.metadata
+
+
+def test_deme_evaluate_allows_ok_maxim():
+    assert DEME().evaluate(Maxim(action_kind="protect")).verdict == "ALLOW"
+
+
+# ----------------------------------------------------- pipeline integration
+
+
+def test_pipeline_vetoes_option_with_failing_maxim():
+    good = EthicalFacts(option_id="good")
+    bad = EthicalFacts(option_id="bad", maxim=Maxim(action_kind="deceive"))
+    result = DEMEPipeline().decide([good, bad])
+    assert "bad" in result.forbidden_options
+    assert "good" not in result.forbidden_options


### PR DESCRIPTION
Wires the polarity-aware `Maxim` that erisml-compiler now emits into the DEME evaluation engine. (Re-opened clean off main; supersedes #116.)

- `ethics/facts.py` — `Maxim(action_kind, polarity)` + optional `EthicalFacts.maxim` (defaults None, backward compatible)
- `ethics/deontic_gate.py` — Kantian universalizability veto honouring polarity (negate a prohibition/permissible → ok; negate an imperfect duty help/protect → veto; unknown → no veto)
- `layers/pipeline.py` — `DEMEPipeline` reflex layer vetoes options whose maxim fails the gate; records `deontic_vetoes`
- `ethics/deme.py` — `DEME.evaluate` honours the gate (FORBID on failure)
- `decision_proof.py` — `hash_ethical_facts` guards `asdict` with `is_dataclass`, fixing a pre-existing crash in `decide()`'s proof phase
- README — documents the compiler→lib dataflow + polarity gate
- `tests/test_deontic_gate.py` — 9 tests (gate logic, DEME.evaluate, full-pipeline veto)

9 new tests pass; 76 passed across regression-relevant suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)