### PR TITLE
Noether Ethics paper: tighten claims to match what is established

### DIFF
--- a/docs/papers/foundations/Noether_Ethics_Paper.tex
+++ b/docs/papers/foundations/Noether_Ethics_Paper.tex
@@ -31,7 +31,7 @@
 \newcommand{\Ob}{\mathbf{O}}
 \newcommand{\G}{\mathcal{G}}
 
-\title{\textbf{Noether's Theorem for Ethics:\\Harm Accounting and the Formal Structure\\of Normative Coherence}}
+\title{\textbf{Noether-Style Reasoning for Ethics:\\Representation-Invariant Harm Accounting\\and the Gauge Analogy of Normative Coherence}}
 
 \author{Andrew H. Bond\\
 Department of Computer Engineering\\
@@ -47,7 +47,7 @@ San Jos\'{e} State University\\
 \noindent\textbf{Keywords:} Noether's theorem, gauge invariance, harm conservation, ethical coherence, Bond Invariance Principle, AI alignment, representation invariance
 
 \begin{abstract}
-We demonstrate that the mathematical structure underlying gauge theory in physics and coherence verification in ethics is formally analogous, and that this analogy has profound consequences. Applying Noether-style reasoning to the re-description symmetry required by ethical consistency, we derive an accounting constraint: \textbf{harm accounting must be representation-invariant}. Just as physical observables cannot depend on gauge choices, ethical harm cannot appear or disappear merely through re-description. Genuine repair is possible---but it must register consistently across all representations. This is not metaphor but formal analogy: the same structural pattern, applied to different domains. We develop the correspondence between electrodynamics and ethics, identifying harm density $\rho_\harm$ with charge density, harm current $J_\harm$ with electric current, and deriving the ethical accounting equation $\partial \rho_\harm / \partial t + \nabla \cdot J_\harm = \sigma$, where $\sigma$ represents genuine harm generation or repair. Incoherence is detected when $\sigma$ changes under re-description. We explore the implications for consequentialism, retributive justice, restorative justice, and the foundations of moral philosophy. We argue that this structural correspondence suggests a deeper mathematical framework---possibly rooted in information geometry or homotopy type theory---underlying both physical and normative reasoning. Throughout, we maintain epistemic humility: we claim not that this structure reveals metaphysical necessity, but that it provides a powerful, empirically grounded tool for understanding the formal constraints on coherent ethical reasoning. The implications for AI alignment are immediate: systems whose harm accounting is representation-dependent are incoherent in a mathematically precise sense.
+We demonstrate that the mathematical structure underlying gauge theory in physics and coherence verification in ethics is formally analogous, and that this analogy has profound consequences. Applying Noether-style reasoning to the re-description symmetry required by ethical consistency, we derive an accounting constraint: \textbf{harm accounting must be representation-invariant}. Just as physical observables cannot depend on gauge choices, ethical harm cannot appear or disappear merely through re-description. Genuine repair is possible---but it must register consistently across all representations. This is not metaphor but formal analogy: the same structural pattern, applied to different domains---though, we stress, a structural analogy and not an identity, since the ethics side fixes no metric, Lagrangian, or dynamics. We develop the correspondence between electrodynamics and ethics, identifying harm density $\rho_\harm$ with charge density, harm current $J_\harm$ with electric current, and \emph{positing}---as an illustrative analogy rather than a derivation from an ethical action---the accounting equation $\partial \rho_\harm / \partial t + \nabla \cdot J_\harm = \sigma$, where $\sigma$ represents genuine harm generation or repair. Incoherence is detected when $\sigma$ changes under re-description. We are explicit throughout about which claims are load-bearing (the coherence/invariance constraint, which is testable) and which are suggestive analogy (the field equations); the empirical support we report is preliminary and carries a stated encoder confound. We explore the implications for consequentialism, retributive justice, restorative justice, and the foundations of moral philosophy. We argue that this structural correspondence suggests a deeper mathematical framework---possibly rooted in information geometry or homotopy type theory---underlying both physical and normative reasoning. Throughout, we maintain epistemic humility: we claim not that this structure reveals metaphysical necessity, but that it provides a powerful, empirically grounded tool for understanding the formal constraints on coherent ethical reasoning. The implications for AI alignment are immediate: systems whose harm accounting is representation-dependent are incoherent in a mathematically precise sense.
 \end{abstract}
 
 \newpage
@@ -58,7 +58,7 @@ We demonstrate that the mathematical structure underlying gauge theory in physic
 \section{Introduction: The Suspicious Coincidence}
 %==============================================================================
 
-In 2025, while developing a categorical framework for verifying representational consistency in AI systems, we noticed something strange. The mathematics we were using---groupoids, double categories, connections, curvature---was identical to the mathematics of gauge theory in physics. Not merely analogous. \textit{Identical}.
+In 2025, while developing a categorical framework for verifying representational consistency in AI systems, we noticed something strange. The mathematics we were using---groupoids, double categories, connections, curvature---was the \textit{same organizing structure} as the mathematics of gauge theory in physics: the same pattern of symmetry, connection, and curvature, not a loose metaphor. We deliberately do \emph{not} claim identity: the ethics side has no metric, no Lagrangian, and no dynamics pinned down, so what we have is a precise \emph{structural} analogy---shared pattern, not shared content. That distinction governs the rest of the paper, and we are careful below to mark where the analogy is load-bearing and where it is merely suggestive.
 
 At first, this seemed like a coincidence, or perhaps an artifact of using powerful mathematical tools that appear in many contexts. But as we developed the framework further, the correspondences became too precise to ignore:
 
@@ -350,6 +350,10 @@ This is the \textbf{Noether-style constraint} for ethics: re-description invaria
 
 \textbf{The smooth limit.} When discrete transforms can be embedded in a continuous group (e.g., option reorderings as permutations embedded in a continuous deformation), the full Noether machinery applies, and we obtain a differential conservation law. This justifies treating the continuous case as a limiting idealization, much as discrete lattice models in physics approach continuum field theories.
 
+\begin{remark}[What the symmetry argument does and does not establish]
+For the discrete re-description groupoid that actually arises in practice, this is \emph{not} Noether's theorem in its load-bearing sense. Noether's content in physics is that a continuous symmetry of a \emph{dynamics} (an action) yields a \emph{non-obvious} conserved current---one you could not read off in advance (phase symmetry $\Rightarrow$ electric charge). Here there is no action and the symmetry is discrete, so what remains is the near-definitional fact that a quantity \emph{declared} invariant under the groupoid is constant on its orbits. The real work is done by the modeling choice---that harm is among the re-description invariants---not by Noether's theorem. We keep the Noether framing because it correctly names the \emph{pattern} (symmetry $\Rightarrow$ invariant) and because the continuous idealization does admit the full machinery; but the honest, load-bearing claim is the coherence constraint below, not a derived conservation law. Its real content is empirical: whether a given system's harm judgments actually respect the invariance (\S9.4--9.5).
+\end{remark}
+
 \subsection{Identifying the Conserved Quantity}
 
 What is the conserved quantity? We argue it is \textbf{harm}.
@@ -401,7 +405,7 @@ Incoherence occurs when the source term changes under re-description---i.e., whe
 \end{theorem}
 
 \begin{proof}
-The proof follows the Noether argument for the continuous case. For the discrete case, the result follows from the requirement that harm accounting be representation-independent: if $H(x) \neq H(g(x))$ for some bond-preserving $g$, then the harm ledger depends on representational choices, which contradicts the definition of bond-preserving transforms.
+The continuous form follows the Noether argument under the idealization of \S4.2. For the discrete case---the one that actually arises---the statement is a \emph{consistency requirement}, not an independently derived law: if $H(x) \neq H(g(x))$ for some bond-preserving $g$, the harm ledger depends on representational choices, contradicting the definition of a bond-preserving transform. In other words, the discrete ``theorem'' is definitional given the modeling choice that harm is bond-invariant; the differential equation is its continuous idealization. Its non-trivial content is empirical (\S9.4--9.5): whether real evaluators honour the constraint.
 \end{proof}
 
 \begin{remark}
@@ -426,6 +430,10 @@ The accounting equation $\partial_t \rho + \nabla \cdot \mathbf{J} = \sigma$ mea
 %==============================================================================
 
 We now develop the complete correspondence between electrodynamics and ethics.
+
+\begin{remark}[Status of this section: suggestive analogy, not derived result]
+The field equations below are \emph{posited by structural analogy}, not derived from an ethical action functional. The coupling constants $\kappa,\lambda$ are unfixed and the fields $\mathbf{E}_\text{ob},\mathbf{B}_\text{sys}$ are not operationally measured. In particular, the continuity equation ``derived'' in \S5.3 recovers the conservation structure that was \emph{assumed} when the equations were written down---it is an internal consistency check on the analogy, not independent evidence for it. We include this section to show how far the correspondence can be pushed and to seed the research conjectures of \S8, and we ask the reader to read it in that spirit. Nothing in \S6--7 (the philosophical and AI-alignment payoffs) depends on these equations; those rest only on the coherence/invariance constraint of \S4.
+\end{remark}
 
 \subsection{The Ethical Field Equations}
 
@@ -873,9 +881,30 @@ Cross-lingual similarity & 86\% & Good semantic invariance \\
 
 The \textbf{11.1x structural/surface ratio} directly validates the core claim of this paper: structural perturbations (changing bonds, altering who owes what to whom) cause dramatically larger embedding shifts than surface perturbations (relabeling, rephrasing). This is the empirical signature of representation-invariant harm accounting.
 
-The \textbf{obligation-permission axis} showing perfect transfer (1.0) suggests that deontic structure---the distinction between what is required, permitted, and forbidden---is genuinely language-invariant, precisely as the gauge-theoretic framework predicts.
+The \textbf{obligation-permission axis} showing perfect transfer (1.0) suggests that deontic structure---the distinction between what is required, permitted, and forbidden---is genuinely language-invariant, consistent with the gauge-theoretic framework.
 
-\textbf{Verdict: STRONGLY\_SUPPORTED}---The Noether-style conservation constraint on ethical reasoning finds substantial empirical support in cross-lingual transfer experiments.
+\textbf{A confound we must foreground.} The cross-lingual results are partly attributable to the \emph{encoder} rather than to language-invariance of ethical structure \emph{per se}. LaBSE is pretrained specifically to align translations in a shared embedding space; transfer of ethical labels across languages therefore conflates ``ethical structure is representation-invariant'' with ``the encoder already aligns languages.'' The low language-leakage (1.2\%) and high cross-lingual similarity (86\%) are exactly what a strong multilingual encoder produces regardless of any ethics-specific invariance. The cleaner, less-confounded signal is the \emph{within-representation} \textbf{structural/surface ratio (11.1x)}: it contrasts structural vs.\ surface perturbations inside the same encoder, so it is not explained by language alignment. A properly controlled test would (i) repeat the structural/surface contrast against a non-translation-aligned encoder, and (ii) treat the ratio, not cross-lingual transfer, as the primary endpoint.
+
+\textbf{Verdict: SUPPORTED, with a stated encoder confound.}---The representation-invariance constraint finds real support in the structural/surface contrast; the cross-lingual transfer figures should be read as consistent-with rather than decisive, pending the controlled replication above. We deliberately downgrade the earlier ``strongly supported'' framing.
+
+\subsection{A Confound-Free Micro-Test: Negation Sensitivity}
+
+The sharpest test of representation-invariance needs no multilingual encoder at all. Negation is the cleanest case of a re-description that is \emph{not} bond-preserving: ``the doctor lied'' and ``the doctor did not lie'' are surface-near but morally opposite, so a coherent evaluator must \emph{distinguish} them while a surface/keyword evaluator cannot.
+
+On a minimal-pair corpus (prohibitions, imperfect duties, and merely-permissible acts, each in affirmed and negated form), we compare the ErisML compiler---which extracts a maxim with polarity via dependency parsing and applies the deontic gate---against a black-box scalar/keyword classifier that stands in for safety filters and reward models~\cite{bond2026erisml}:
+
+\begin{center}
+\begin{tabular}{lccc}
+\toprule
+\textbf{System} & \textbf{overall} & \textbf{negated items} & \textbf{reasoning fields} \\
+\midrule
+ErisML compiler        & 100\% & 100\% & 4 \\
+Black-box scalar/keyword & 58\% & 33\% & 0 \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+The keyword baseline forbids ``did not lie'' (the token \emph{lie} is present) and even forbids ``helped the \emph{injured} man'' (a harm word it cannot bind to the agent's action); the structure-preserving pipeline tracks the maxim and its polarity, and emits an inspectable trace (action kind, polarity, contradiction type, justification). This is a small, hand-built probe targeting one phenomenon---not a broad moral-competence benchmark, and a modern LLM judge would handle the negation too (while still failing the auditability and determinism axes). But it is \emph{confound-free}: it isolates representation-sensitivity with no encoder doing hidden work, and it is exactly the signature the BIP predicts---surface-invariance where the re-description is bond-preserving, and surface-\emph{sensitivity} where it is not.
 
 \subsection{Future Directions}
 
@@ -1009,11 +1038,11 @@ J^\mu = \frac{\partial \mathcal{L}}{\partial (\partial_\mu \phi)} \delta \phi - 
 \end{equation}
 where $K^\mu$ arises if the Lagrangian changes by a total derivative.
 
-\subsection{Groupoid Noether Theorem}
+\subsection{Invariants of a Groupoid Action (the discrete ``Noether'' analog)}
 
-For discrete groupoid symmetries, the analog of Noether's theorem involves invariants of the groupoid action. If $\G$ acts on a space $X$ and a quantity $f: X \to \R$ is $\G$-invariant ($f(gx) = f(x)$ for all $g \in \G$), then $f$ descends to the orbit space $X/\G$.
+For the discrete re-description groupoid the relevant fact is \emph{not} a Noether-type theorem but the elementary observation that a $\G$-invariant quantity descends to the orbit space. If $\G$ acts on $X$ and $f: X \to \R$ satisfies $f(gx) = f(x)$ for all $g \in \G$, then $f$ factors through $X/\G$. This is essentially the \emph{definition} of invariance, not a consequence of dynamics; we call it ``Noether'' only by analogy with the continuous case, where a symmetry of an action produces a genuinely non-obvious conserved current.
 
-The conserved ``charge'' is any $\G$-invariant quantity. In the ethical context, harm is the $\G$-invariant quantity under re-description symmetry.
+Accordingly, the framework \emph{posits} harm to be among the $\G$-invariants under re-description; that is a modeling choice, not a derivation. The non-trivial, falsifiable content is then empirical: whether a given evaluator's harm judgments actually respect the invariance.
 
 \section{The Ethical Stress-Energy Tensor}
 


### PR DESCRIPTION
Honesty pass on the Noether Ethics paper, separating the load-bearing structural analogy from borrowed grandeur.

- **Title**: "Noether's Theorem for Ethics" → "Noether-Style Reasoning for Ethics: Representation-Invariant Harm Accounting and the Gauge Analogy of Normative Coherence"
- **Abstract / §1**: drop "identical, not analogous" → precise *structural* analogy; "deriving" the field equation → "positing, by analogy"
- **§4**: remark that the discrete case is *not* load-bearing Noether but the near-definitional descent of invariants to the quotient; reframe the "theorem" proof as a consistency requirement; the content is empirical
- **§5**: mark the ethical Maxwell equations as posited-by-analogy; flag the continuity "derivation" as recovering assumed structure, not evidence
- **§9.4**: foreground the LaBSE encoder confound; downgrade `STRONGLY_SUPPORTED` → `SUPPORTED`, with the within-encoder structural/surface ratio as the cleaner signal
- **§9.5 (new)**: confound-free negation micro-test (ErisML 100% vs black-box 33% on negated minimal pairs)
- **Appendix**: relabel "Groupoid Noether Theorem" as invariants of a groupoid action (definitional)

Submission copies left untouched. Env balance verified (104/104).

🤖 Generated with [Claude Code](https://claude.com/claude-code)