### PR TITLE
ci: add ty type-check (advisory)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,15 @@ jobs:
           ruff check src tests
 
       # -----------------------------
+      # Type check (ty — advisory)
+      # -----------------------------
+      - name: Type check (ty — advisory)
+        continue-on-error: true  # ty is preview (0.0.x); advisory until src/erisml is ty-clean
+        run: |
+          pip install ty==0.0.55
+          ty check src/erisml
+
+      # -----------------------------
       # Validate pyproject.toml
       # -----------------------------
       - name: Validate pyproject.toml syntax (Taplo)


### PR DESCRIPTION
Adds Astral's `ty` as a non-blocking advisory step in the lint job (continue-on-error). ~849 diagnostics on src/erisml currently; reports in logs without failing CI. Make blocking once ty-clean.