### PR TITLE
fix(parser): raise validation errors

### DIFF
--- a/src/erisml/language/grammar.lark
+++ b/src/erisml/language/grammar.lark
@@ -9,7 +9,7 @@ model: environment_block agent_block+ norms_block? ethics_block? dynamics_block?
 // Environment Block
 // ============================================================================
 environment_block: "environment" CNAME "{" env_body "}"
-env_body: objects_decl state_decl env_dynamics_decl?
+env_body: objects_decl state_decl
 
 objects_decl: "objects:" CNAME ("," CNAME)* ";"
 state_decl: "state:" state_var_decl*
@@ -17,7 +17,7 @@ state_var_decl: CNAME ":" type_expr ";"
 
 type_expr: base_type
          | CNAME "->" base_type
-base_type: "bool" | "int" | "real" | "(" type_expr "," type_expr ")"
+base_type: BASE_TYPE | "(" type_expr "," type_expr ")"
 
 // ============================================================================
 // Agent Block
@@ -108,6 +108,7 @@ reward_term: CNAME ":" expr ";"
 // Terminals
 // ============================================================================
 STRING: "\"" /[^"]*/ "\""
+BASE_TYPE.10: "bool" | "int" | "real"
 %import common.CNAME
 %import common.NUMBER
 %import common.WS

--- a/src/erisml/language/parser.py
+++ b/src/erisml/language/parser.py
@@ -43,6 +43,10 @@ def _grammar_text() -> str:
 _PARSER = Lark(_grammar_text(), start="model", parser="lalr")
 
 
+class ParsingError(ValueError):
+    pass
+
+
 class ASTBuilder(Transformer):
     def environment_block(self, items: List[Any]) -> EnvDecl:
         name_token: Token = items[0]
@@ -73,6 +77,11 @@ class ASTBuilder(Transformer):
         texpr: TypeExpr = items[1]
         return StateVarDecl(name=name_token.value, type=texpr)
 
+    def base_type(self, items: List[Any]) -> Token:
+        if len(items) == 1 and isinstance(items[0], Token):
+            return items[0]
+        raise ParsingError("Tuple type expressions are not supported")
+
     def type_expr(self, items: List[Any]) -> TypeExpr:
         if len(items) == 1:
             base = items[0].value
@@ -85,7 +94,9 @@ class ASTBuilder(Transformer):
                 base=base_type.value,
                 key_object_type=key_type.value,
             )
-        raise ValueError("Invalid type_expr items")
+        raise ParsingError(
+            "Invalid type expression: expected a base type or mapping type"
+        )
 
     def agent_block(self, items: List[Any]) -> AgentDecl:
         name_token: Token = items[0]
@@ -168,7 +179,8 @@ class ASTBuilder(Transformer):
                 agents.append(item)
             elif isinstance(item, NormsDecl):
                 norms = item
-        assert env is not None, "Model must have an environment"
+        if env is None:
+            raise ParsingError("Model must have an environment")
         return ModelAST(environment=env, agents=agents, norms=norms)
 
 
@@ -176,5 +188,6 @@ def parse_erisml(source: str) -> ModelAST:
     # Parse ErisML source code into a typed AST.
     tree = _PARSER.parse(source)
     ast = ASTBuilder().transform(tree)
-    assert isinstance(ast, ModelAST)
+    if not isinstance(ast, ModelAST):
+        raise ParsingError("Parser produced an invalid ModelAST")
     return ast

--- a/tests/test_language_parser.py
+++ b/tests/test_language_parser.py
@@ -1,0 +1,55 @@
+import pytest
+
+from erisml.language.ast import AgentDecl
+
+VALID_MODEL = (
+    "environment Home {\n"
+    "  objects: Room;\n"
+    "  state:\n"
+    "    occupied: bool;\n"
+    "}\n"
+    "\n"
+    "agent Robot {\n"
+    "  capabilities: move;\n"
+    "}\n"
+)
+
+
+def test_parse_erisml_returns_model_ast_for_minimal_model() -> None:
+    from erisml.language.parser import parse_erisml
+
+    model = parse_erisml(VALID_MODEL)
+
+    assert model.environment.name == "Home"
+    assert model.agents[0].name == "Robot"
+
+
+def test_type_expr_rejects_unexpected_transform_items() -> None:
+    from erisml.language.parser import ASTBuilder, ParsingError
+
+    with pytest.raises(ParsingError, match="Invalid type expression"):
+        ASTBuilder().type_expr([])
+
+
+def test_model_rejects_missing_environment() -> None:
+    from erisml.language.parser import ASTBuilder, ParsingError
+
+    agent = AgentDecl(name="Robot", capabilities=["move"])
+
+    with pytest.raises(ParsingError, match="Model must have an environment"):
+        ASTBuilder().model([agent])
+
+
+def test_parse_erisml_rejects_invalid_transformed_ast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from erisml.language import parser
+
+    class InvalidASTBuilder:
+        def transform(self, tree: object) -> object:
+            return tree
+
+    monkeypatch.setattr(parser, "ASTBuilder", InvalidASTBuilder)
+
+    with pytest.raises(parser.ParsingError, match="ModelAST"):
+        parser.parse_erisml(VALID_MODEL)


### PR DESCRIPTION
## Summary
- replace parser validation asserts with explicit `ParsingError` exceptions
- remove the stale `env_dynamics_decl` grammar reference that prevented the parser from loading
- give scalar base types their own terminal so minimal ErisML models parse deterministically
- add parser regression tests for the valid minimal model and validation error paths

Fixes #134.

## Root cause
The current `main` parser still used `assert` for validation in `ASTBuilder.model()` and `parse_erisml()`, so optimized Python could bypass the intended checks. While adding the regression coverage, the parser also failed to import from current HEAD because `grammar.lark` referenced an undefined `env_dynamics_decl`; after that was removed, scalar type literals still tokenized as `CNAME` instead of base types.

## Duplicate and stale checks
- Issue #134 was open immediately before work and immediately before PR creation.
- Open PR duplicate search for `134 OR parser assert OR ParsingError OR ValueError OR env_dynamics_decl OR GrammarError` returned no results before work and again before PR creation.
- Historical PR search for parser assertion / grammar error terms also returned no results before work.

## Verification
- RED before fix: `PYTHONPATH=src PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with lark --with pydantic --with pytest --with pytest-cov python -m pytest tests/test_language_parser.py -q -p pytest_cov -o addopts=''` failed with `GrammarError: Rule 'env_dynamics_decl' used but not defined` on all four new parser tests.
- GREEN after fix: same focused parser command passed, 4 tests.
- `UV_LINK_MODE=copy PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_language_parser.py tests/test_basic.py -q -p pytest_cov -o addopts=''`
- `uv run --no-project --with ruff==0.15.0 ruff check src/erisml/language/parser.py tests/test_language_parser.py`
- `uv run --no-project --with black==26.1.0 black --check src/erisml/language/parser.py tests/test_language_parser.py`
- `uv run --no-project --with ty==0.0.55 ty check src/erisml/language/parser.py`
- `PYTHONPATH=src uv run --no-project --with lark --with pydantic python -O - <<'PY' ... PY` confirmed invalid transformed AST raises `ParsingError` under optimized Python.
- `git diff --check`